### PR TITLE
Determine source level

### DIFF
--- a/actions/vsa_creator/determine_source_level_gh.sh
+++ b/actions/vsa_creator/determine_source_level_gh.sh
@@ -16,4 +16,17 @@ GITHUB_RULESET=$(curl -L \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/${REPO}/rules/branches/${BRANCH})
 
-echo $GITHUB_RULESET
+# Check continuity requirement
+# We'll assume it meets this requirement if the branch prevents deletions
+# and force pushes.
+# TODO: Should other things be checked too?
+NO_DELETION=$(echo $GITHUB_RULESET | jq '.[] | select(.type=="deletion")')
+NO_FORCE_PUSH=$(echo $GITHUB_RULESET | jq '.[] | select(.type=="non_fast_forward") | any')
+
+SOURCE_LEVEL="SLSA_SOURCE_LEVEL_1"
+
+# TODO: this isn't working, we'd expect to this to work for `TomHennen/slsa-source-poc main`
+if [ "$NO_DELETION" = "true" ] && [ "$NO_FORCE_PUSH" = "true" ]; then
+    SOURCE_LEVEL="SLSA_SOURCE_LEVEL_2"
+fi
+echo $SOURCE_LEVEL


### PR DESCRIPTION
If you run this script as `determine_source_level_gh.sh foo TomHennen/slsa-source-poc main` then the idea is that it _should_ emit SLSA_SOURCE_LEVEL_2 (it doesn't right now) because of how the rulesets are configured for that repo.

Once this actually works we should be able to update the create_vsa.sh script to accept the level as a parameter (or maybe that script calls this one? IDK) and then get the computed level embedded in the VSA.