### PR TITLE
HACK: Sign with witness

### DIFF
--- a/.github/workflows/create_slsa_source_vsa.yml
+++ b/.github/workflows/create_slsa_source_vsa.yml
@@ -12,4 +12,4 @@ jobs:
     - name: vsa
       # TODO: only generate VSAs for official pushes? IDK
       # TODO: Can we make this work for forks too?
-      uses: slsa-framework/slsa-source-poc/actions/vsa_creator@sign_with_witness
+      uses: TomHennen/slsa-source-poc/actions/vsa_creator@sign_with_witness

--- a/.github/workflows/create_slsa_source_vsa.yml
+++ b/.github/workflows/create_slsa_source_vsa.yml
@@ -7,6 +7,7 @@ jobs:
   create_vsa:
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - name: vsa

--- a/.github/workflows/create_slsa_source_vsa.yml
+++ b/.github/workflows/create_slsa_source_vsa.yml
@@ -13,4 +13,4 @@ jobs:
     - name: vsa
       # TODO: only generate VSAs for official pushes? IDK
       # TODO: Can we make this work for forks too?
-      uses: TomHennen/slsa-source-poc/actions/vsa_creator@sign_with_witness
+      uses: slsa-framework/slsa-source-poc/actions/vsa_creator@main

--- a/.github/workflows/create_slsa_source_vsa.yml
+++ b/.github/workflows/create_slsa_source_vsa.yml
@@ -12,4 +12,4 @@ jobs:
     - name: vsa
       # TODO: only generate VSAs for official pushes? IDK
       # TODO: Can we make this work for forks too?
-      uses: slsa-framework/slsa-source-poc/actions/vsa_creator@main
+      uses: slsa-framework/slsa-source-poc/actions/vsa_creator@sign_with_witness

--- a/.github/workflows/local_attest.yml
+++ b/.github/workflows/local_attest.yml
@@ -9,4 +9,4 @@ jobs:
     permissions:
       contents: read
     # TODO: Can we make this work for forks too?
-    uses: slsa-framework/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@main
+    uses: slsa-framework/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@sign_with_witness

--- a/.github/workflows/local_attest.yml
+++ b/.github/workflows/local_attest.yml
@@ -8,5 +8,6 @@ jobs:
   check-change:
     permissions:
       contents: read
+      id-token: write
     # TODO: Can we make this work for forks too?
     uses: TomHennen/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@sign_with_witness

--- a/.github/workflows/local_attest.yml
+++ b/.github/workflows/local_attest.yml
@@ -9,4 +9,4 @@ jobs:
     permissions:
       contents: read
     # TODO: Can we make this work for forks too?
-    uses: slsa-framework/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@sign_with_witness
+    uses: TomHennen/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@sign_with_witness

--- a/.github/workflows/local_attest.yml
+++ b/.github/workflows/local_attest.yml
@@ -10,4 +10,4 @@ jobs:
       contents: read
       id-token: write
     # TODO: Can we make this work for forks too?
-    uses: TomHennen/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@sign_with_witness
+    uses: slsa-framework/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@main

--- a/actions/vsa_creator/action.yml
+++ b/actions/vsa_creator/action.yml
@@ -24,6 +24,24 @@ runs:
       run: |
         cat ${{ github.workspace }}/metadata/unsigned_vsa.json >> $GITHUB_STEP_SUMMARY
       shell: bash
+    - id: install_witness
+      # This is a bit of a hack, running witness happens to also install it.
+      # We don't care much about what it does here, we just want the side-effect of witness being installed.
+      # If this works well we might lodge some feature requests?
+      uses: testifysec/witness-run-action@reusable-workflow
+      with:
+        command: /bin/sh echo "hello from slsa-source-poc"
+        step: "install_witness"
+    - id: sign_vsa
+      # Use witness to sign that VSA...
+      run: |
+        witness sign -f ${{ github.workspace }}/metadata/unsigned_vsa.json -t "application/vnd.in-toto+json" -o ${{ github.workspace }}/metadata/signed_vsa.json \
+        --signer-fulcio-url https://fulcio.sigstore.dev \
+        --signer-fulcio-oidc-client-id sigstore \
+        --signer-fulcio-oidc-issuer https://oauth2.sigstore.dev/auth \
+        --timestamp-servers https://freetsa.org/tsr
+        cat ${{ github.workspace }}/metadata/signed_vsa.json >> $GITHUB_STEP_SUMMARY
+      shell: bash
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/actions/vsa_creator/action.yml
+++ b/actions/vsa_creator/action.yml
@@ -30,7 +30,7 @@ runs:
       # If this works well we might lodge some feature requests?
       uses: testifysec/witness-run-action@reusable-workflow
       with:
-        command: /bin/sh echo "hello from slsa-source-poc"
+        command: /bin/sh -c "echo \"hello from slsa-source-poc\""
         step: "install_witness"
     - id: sign_vsa
       # Use witness to sign that VSA...

--- a/actions/vsa_creator/action.yml
+++ b/actions/vsa_creator/action.yml
@@ -22,6 +22,7 @@ runs:
       shell: bash
     - id: summary
       run: |
+        echo "## Unsigned VSA" >> $GITHUB_STEP_SUMMARY
         cat ${{ github.workspace }}/metadata/unsigned_vsa.json >> $GITHUB_STEP_SUMMARY
       shell: bash
     - id: install_witness
@@ -40,6 +41,7 @@ runs:
         --signer-fulcio-oidc-client-id sigstore \
         --signer-fulcio-oidc-issuer https://oauth2.sigstore.dev/auth \
         --timestamp-servers https://freetsa.org/tsr
+        echo "## Signed VSA" >> $GITHUB_STEP_SUMMARY
         cat ${{ github.workspace }}/metadata/signed_vsa.json >> $GITHUB_STEP_SUMMARY
       shell: bash
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Here's a fairly hacky way to get the VSA signed by Sigstore during the workflow.

This (ab)uses testifysec/witness-run-action to get witness installed so that it can then sign an arbitrary blob with witness's Sigstore support.

The result is a signed VSA that attests to this workflows determination of the SLSA Source Level (for whatever good that is).

In the future:
1. We still want to _store_ this attestation someplace reasonable.
2. We might want to pivot to gitsign once we're able to sign stuff with it.
3. We'd definitely want to remove the hack...

Thanks to @jkjell for telling me how to get this working. :)