### PR TITLE
Add 'provenance' basics

### DIFF
--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -18,7 +18,6 @@ import (
 
 type CheckLevelArgs struct {
 	commit, owner, repo, branch, outputVsa, outputUnsignedVsa string
-	minDays                                                   int
 }
 
 // checklevelCmd represents the checklevel command
@@ -32,12 +31,12 @@ var (
 
 This is meant to be run within the corresponding GitHub Actions workflow.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			doCheckLevel(checkLevelArgs.commit, checkLevelArgs.owner, checkLevelArgs.repo, checkLevelArgs.branch, checkLevelArgs.minDays, checkLevelArgs.outputVsa, checkLevelArgs.outputUnsignedVsa)
+			doCheckLevel(checkLevelArgs.commit, checkLevelArgs.owner, checkLevelArgs.repo, checkLevelArgs.branch, checkLevelArgs.outputVsa, checkLevelArgs.outputUnsignedVsa)
 		},
 	}
 )
 
-func doCheckLevel(commit, owner, repo, branch string, minDays int, outputVsa, outputUnsignedVsa string) {
+func doCheckLevel(commit, owner, repo, branch, outputVsa, outputUnsignedVsa string) {
 	if commit == "" || owner == "" || repo == "" || branch == "" {
 		log.Fatal("Must set commit, owner, repo, and branch flags.")
 	}
@@ -45,7 +44,7 @@ func doCheckLevel(commit, owner, repo, branch string, minDays int, outputVsa, ou
 	gh_client := github.NewClient(nil)
 	ctx := context.Background()
 
-	sourceLevel, err := checklevel.DetermineSourceLevel(ctx, gh_client, commit, owner, repo, branch, minDays)
+	sourceLevel, err := checklevel.DetermineSourceLevelControlOnly(ctx, gh_client, commit, owner, repo, branch)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -84,7 +83,6 @@ func init() {
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.owner, "owner", "", "The GitHub repository owner - required.")
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.repo, "repo", "", "The GitHub repository name - required.")
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.branch, "branch", "", "The branch within the repository - required.")
-	checklevelCmd.Flags().IntVar(&checkLevelArgs.minDays, "min_days", 1, "The minimum duration that the rules need to have been enabled for.")
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.outputVsa, "output_vsa", "", "The path to write a signed VSA with the determined level.")
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.outputUnsignedVsa, "output_unsigned_vsa", "", "The path to write an unsigned vsa with the determined level.")
 }

--- a/sourcetool/cmd/prov.go
+++ b/sourcetool/cmd/prov.go
@@ -1,0 +1,63 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/provenance"
+
+	"github.com/google/go-github/v68/github"
+	"github.com/spf13/cobra"
+)
+
+type ProvArgs struct {
+	prevAttPath, commit, prevCommit, owner, repo, branch string
+}
+
+// provCmd represents the prov command
+var (
+	provArgs ProvArgs
+	provCmd  = &cobra.Command{
+		Use:   "prov",
+		Short: "A brief description of your command",
+		Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			doProv(provArgs.prevAttPath, provArgs.commit, provArgs.prevCommit, provArgs.owner, provArgs.repo, provArgs.branch)
+		},
+	}
+)
+
+func doProv(prevAttPath, commit, prevCommit, owner, repo, branch string) {
+	gh_client := github.NewClient(nil)
+	ctx := context.Background()
+	newProv, err := provenance.CreateSourceProvenance(ctx, gh_client, prevAttPath, commit, prevCommit, owner, repo, branch)
+	if err != nil {
+		log.Fatal(err)
+	}
+	provStr, err := json.Marshal(newProv)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", string(provStr))
+}
+
+func init() {
+	rootCmd.AddCommand(provCmd)
+
+	provCmd.Flags().StringVar(&provArgs.prevAttPath, "prev_att_path", "", "Path to the file with the attestations for the previous commit (as an in-toto bundle).")
+	provCmd.Flags().StringVar(&provArgs.commit, "commit", "", "The commit to check.")
+	provCmd.Flags().StringVar(&provArgs.prevCommit, "prev_commit", "", "The commit prior to 'commit'.")
+	provCmd.Flags().StringVar(&provArgs.owner, "owner", "", "The GitHub repository owner - required.")
+	provCmd.Flags().StringVar(&provArgs.repo, "repo", "", "The GitHub repository name - required.")
+	provCmd.Flags().StringVar(&provArgs.branch, "branch", "", "The branch within the repository - required.")
+}

--- a/sourcetool/pkg/checklevel/checklevel.go
+++ b/sourcetool/pkg/checklevel/checklevel.go
@@ -68,7 +68,12 @@ func commitPushTime(ctx context.Context, gh_client *github.Client, commit string
 	return time.Time{}, errors.New(fmt.Sprintf("Could not find repo activity for commit %s", commit))
 }
 
-func DetermineSourceLevel(ctx context.Context, gh_client *github.Client, commit string, owner string, repo string, branch string, minDays int) (string, error) {
+// Determines the source level using GitHub's built in controls only.
+// This is necessarily only as good as GitHub's controls and existing APIs.
+// This is a useful demonstration on how SLSA Level 2 can be acheived with ~minimal effort.
+//
+// Returns the determined source level (level 2 max) or error.
+func DetermineSourceLevelControlOnly(ctx context.Context, gh_client *github.Client, commit string, owner string, repo string, branch string) (string, error) {
 	rules, _, err := gh_client.Repositories.GetRulesForBranch(ctx, owner, repo, branch)
 
 	if err != nil {
@@ -125,4 +130,28 @@ func DetermineSourceLevel(ctx context.Context, gh_client *github.Client, commit 
 	}
 
 	return policy.SlsaSourceLevel1, nil
+}
+
+type SourceProvenanceProperty struct {
+	// The name of the property.
+	Name string
+	// The time from which this property has been continuously enforced.
+	Since time.Time
+}
+type SourceProvenance struct {
+	// The commit this provenance documents.
+	Commit string `json:"commit"`
+	// The commit preceeding 'Commit' in the current context.
+	PrevCommit string `json:"prev_commit"`
+	// The properties observed for this commit.
+	Properties []SourceProvenanceProperty `json:"properties"`
+}
+
+func DetermineSourceLevelProvenance() {
+
+	// Compute current provenance based on existing controls only.
+	//   Check to see if there's prov for the prior commit, if not return cur_prov
+	//   Update 'since' for properties on cur_prov to be MIN(cur_prov[prop].since, prior_prov[prop].since)
+	//   Ignore properties on prior_prov that don't exist in cur_prov.
+	// Then check updated_cur_prov based on policy. Make sure updated_cur_prov[prop].since <= policy[prop].since.
 }

--- a/sourcetool/pkg/checklevel/checklevel.go
+++ b/sourcetool/pkg/checklevel/checklevel.go
@@ -131,27 +131,3 @@ func DetermineSourceLevelControlOnly(ctx context.Context, gh_client *github.Clie
 
 	return policy.SlsaSourceLevel1, nil
 }
-
-type SourceProvenanceProperty struct {
-	// The name of the property.
-	Name string
-	// The time from which this property has been continuously enforced.
-	Since time.Time
-}
-type SourceProvenance struct {
-	// The commit this provenance documents.
-	Commit string `json:"commit"`
-	// The commit preceeding 'Commit' in the current context.
-	PrevCommit string `json:"prev_commit"`
-	// The properties observed for this commit.
-	Properties []SourceProvenanceProperty `json:"properties"`
-}
-
-func DetermineSourceLevelProvenance() {
-
-	// Compute current provenance based on existing controls only.
-	//   Check to see if there's prov for the prior commit, if not return cur_prov
-	//   Update 'since' for properties on cur_prov to be MIN(cur_prov[prop].since, prior_prov[prop].since)
-	//   Ignore properties on prior_prov that don't exist in cur_prov.
-	// Then check updated_cur_prov based on policy. Make sure updated_cur_prov[prop].since <= policy[prop].since.
-}

--- a/sourcetool/pkg/provenance/provenance.go
+++ b/sourcetool/pkg/provenance/provenance.go
@@ -1,0 +1,80 @@
+package provenance
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/checklevel"
+)
+
+type SourceProvenanceProperty struct {
+	// The time from which this property has been continuously enforced.
+	Since time.Time
+}
+type SourceProvenance struct {
+	// The commit this provenance documents.
+	Commit string `json:"commit"`
+	// The commit preceeding 'Commit' in the current context.
+	PrevCommit string `json:"prev_commit"`
+	// The properties observed for this commit.
+	Properties map[string]SourceProvenanceProperty `json:"properties"`
+}
+
+func createCurrentProvenance(ctx context.Context, gh_client *github.Client, commit, prevCommit, owner, repo, branch string) (*SourceProvenance, error) {
+	sourceLevel, err := checklevel.DetermineSourceLevelControlOnly(ctx, gh_client, commit, owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+
+	levelProp := SourceProvenanceProperty{Since: time.Now()}
+	var curProv SourceProvenance
+	curProv.Commit = commit
+	curProv.PrevCommit = prevCommit
+	curProv.Properties[sourceLevel] = levelProp
+
+	return &curProv, nil
+}
+
+func getPrevProvenance(ctx context.Context, gh_client *github.Client, prevCommit string) (*SourceProvenance, error) {
+	return nil, nil
+}
+
+func CreateSourceProvenance(ctx context.Context, gh_client *github.Client, commit, prevCommit, owner, repo, branch string) (*SourceProvenance, error) {
+	// Source provenance is based on
+	// 1. The current control situation (we assume 'commit' has _just_ occurred).
+	// 2. How long the properties have been enforced according to the previous provenance.
+
+	curProv, err := createCurrentProvenance(ctx, gh_client, commit, prevCommit, owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("curProv.commit %v", curProv.Commit)
+
+	prevProv, err := getPrevProvenance(ctx, gh_client, prevCommit)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("prevProv.commit %v", prevProv.Commit)
+
+	// No prior provenance found, so we just go with current.
+	if prevProv == nil {
+		return curProv, nil
+	}
+
+	// There was prior provenance, so update the Since field for each property
+	// to the oldest encountered.
+	for propName, curProp := range curProv.Properties {
+		prevProp, ok := prevProv.Properties[propName]
+		if !ok {
+			continue
+		}
+		if prevProp.Since.Before(curProp.Since) {
+			curProp.Since = prevProp.Since
+			curProv.Properties[propName] = curProp
+		}
+	}
+
+	return curProv, nil
+}


### PR DESCRIPTION
Add basics needed for provenance

* Taking the prior attestations as input (too difficult to deal with notes within go)
* Some basic logic for creating the provenance itself and merging results with the prior provenance

Still more to do (like hooking this up at least)