### PR TITLE
Verify identity of issuer

### DIFF
--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -12,7 +12,6 @@ import (
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
 
-	"github.com/google/go-github/v68/github"
 	"github.com/spf13/cobra"
 )
 
@@ -41,17 +40,17 @@ func doCheckLevel(commit, owner, repo, branch, outputVsa, outputUnsignedVsa stri
 		log.Fatal("Must set commit, owner, repo, and branch flags.")
 	}
 
-	gh_client := github.NewClient(nil)
+	gh_connection := gh_control.NewGhConnection(owner, repo, branch)
 	ctx := context.Background()
 
-	controlStatus, err := gh_control.DetermineSourceLevelControlOnly(ctx, gh_client, commit, owner, repo, branch)
+	controlStatus, err := gh_connection.DetermineSourceLevelControlOnly(ctx, commit)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Print(controlStatus.ControlLevel)
 
 	if outputUnsignedVsa != "" {
-		unsignedVsa, err := attest.CreateUnsignedSourceVsa(owner, repo, commit, controlStatus.ControlLevel)
+		unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, commit, controlStatus.ControlLevel)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -63,7 +62,7 @@ func doCheckLevel(commit, owner, repo, branch, outputVsa, outputUnsignedVsa stri
 
 	if outputVsa != "" {
 		// This will output in the sigstore bundle format.
-		signedVsa, err := attest.CreateSignedSourceVsa(owner, repo, commit, controlStatus.ControlLevel)
+		signedVsa, err := attest.CreateSignedSourceVsa(gh_connection, commit, controlStatus.ControlLevel)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -34,13 +34,7 @@ var (
 
 	checklevelprovCmd = &cobra.Command{
 		Use:   "checklevelprov",
-		Short: "A brief description of your command",
-		Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+		Short: "Checks the given commit against policy using & creating provenance",
 		Run: func(cmd *cobra.Command, args []string) {
 			doCheckLevelProv(checkLevelProvArgs)
 		},

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -10,10 +10,10 @@ import (
 	"os"
 
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/google/go-github/v68/github"
 	"github.com/spf13/cobra"
 )
 
@@ -42,23 +42,24 @@ var (
 )
 
 func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
-	gh_client := github.NewClient(nil)
+	gh_connection :=
+		gh_control.NewGhConnection(checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.branch)
 	ctx := context.Background()
 
-	pa := attest.NewProvenanceAttestor(gh_client, attest.DefaultVerifierOptions)
-	p, err := pa.CreateSourceProvenance(ctx, checkLevelProvArgs.prevBundlePath, checkLevelProvArgs.commit, checkLevelProvArgs.prevCommit, checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.branch)
+	pa := attest.NewProvenanceAttestor(gh_connection, attest.DefaultVerifierOptions)
+	p, err := pa.CreateSourceProvenance(ctx, checkLevelProvArgs.prevBundlePath, checkLevelProvArgs.commit, checkLevelProvArgs.prevCommit)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// check p against policy
-	level, err := policy.EvaluateProv(ctx, gh_client, checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.branch, p)
+	level, err := policy.EvaluateProv(ctx, gh_connection, p)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// create vsa
-	unsignedVsa, err := attest.CreateUnsignedSourceVsa(checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.commit, level)
+	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, checkLevelProvArgs.commit, level)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -51,7 +51,8 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 	gh_client := github.NewClient(nil)
 	ctx := context.Background()
 
-	p, err := attest.CreateSourceProvenance(ctx, gh_client, checkLevelProvArgs.prevBundlePath, checkLevelProvArgs.commit, checkLevelProvArgs.prevCommit, checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.branch)
+	pa := attest.NewProvenanceAttestor(gh_client, attest.DefaultVerifierOptions)
+	p, err := pa.CreateSourceProvenance(ctx, checkLevelProvArgs.prevBundlePath, checkLevelProvArgs.commit, checkLevelProvArgs.prevCommit, checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.branch)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -26,6 +26,8 @@ type CheckLevelProvArgs struct {
 	branch               string
 	outputUnsignedBundle string
 	outputSignedBundle   string
+	expectedIssuer       string
+	expectedSan          string
 }
 
 // checklevelprovCmd represents the checklevelprov command
@@ -46,7 +48,15 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 		gh_control.NewGhConnection(checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.branch)
 	ctx := context.Background()
 
-	pa := attest.NewProvenanceAttestor(gh_connection, attest.DefaultVerifierOptions)
+	ver_options := attest.DefaultVerifierOptions
+	if checkLevelProvArgs.expectedIssuer != "" {
+		ver_options.ExpectedIssuer = checkLevelProvArgs.expectedIssuer
+	}
+	if checkLevelProvArgs.expectedSan != "" {
+		ver_options.ExpectedSan = checkLevelProvArgs.expectedSan
+	}
+
+	pa := attest.NewProvenanceAttestor(gh_connection, ver_options)
 	p, err := pa.CreateSourceProvenance(ctx, checkLevelProvArgs.prevBundlePath, checkLevelProvArgs.commit, checkLevelProvArgs.prevCommit)
 	if err != nil {
 		log.Fatal(err)
@@ -120,4 +130,7 @@ func init() {
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.branch, "branch", "", "The branch within the repository - required.")
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.outputUnsignedBundle, "output_unsigned_bundle", "", "The path to write a bundle of unsigned attestations.")
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.outputSignedBundle, "output_signed_bundle", "", "The path to write a bundle of signed attestations.")
+	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.expectedIssuer, "expected_issuer", "", "The expected issuer of attestations.")
+	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.expectedSan, "expected_san", "", "The expect san of attestations.")
+
 }

--- a/sourcetool/cmd/createpolicy.go
+++ b/sourcetool/cmd/createpolicy.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
 
 	"github.com/spf13/cobra"
@@ -35,9 +35,9 @@ var (
 )
 
 func doCreatePolicy(policyRepoPath, owner, repo, branch string) {
-	gh_client := github.NewClient(nil)
+	gh_connection := gh_control.NewGhConnection(owner, repo, branch)
 	ctx := context.Background()
-	outpath, err := policy.CreateLocalPolicy(ctx, gh_client, policyRepoPath, owner, repo, branch)
+	outpath, err := policy.CreateLocalPolicy(ctx, gh_connection, policyRepoPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/cmd/prov.go
+++ b/sourcetool/cmd/prov.go
@@ -24,13 +24,7 @@ var (
 	provArgs ProvArgs
 	provCmd  = &cobra.Command{
 		Use:   "prov",
-		Short: "A brief description of your command",
-		Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+		Short: "Creates provenance for the given commit, but does not check policy.",
 		Run: func(cmd *cobra.Command, args []string) {
 			doProv(provArgs.prevAttPath, provArgs.commit, provArgs.prevCommit, provArgs.owner, provArgs.repo, provArgs.branch)
 		},

--- a/sourcetool/cmd/prov.go
+++ b/sourcetool/cmd/prov.go
@@ -40,7 +40,8 @@ to quickly create a Cobra application.`,
 func doProv(prevAttPath, commit, prevCommit, owner, repo, branch string) {
 	gh_client := github.NewClient(nil)
 	ctx := context.Background()
-	newProv, err := attest.CreateSourceProvenance(ctx, gh_client, prevAttPath, commit, prevCommit, owner, repo, branch)
+	pa := attest.NewProvenanceAttestor(gh_client, attest.DefaultVerifierOptions)
+	newProv, err := pa.CreateSourceProvenance(ctx, prevAttPath, commit, prevCommit, owner, repo, branch)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/cmd/prov.go
+++ b/sourcetool/cmd/prov.go
@@ -9,9 +9,9 @@ import (
 	"log"
 
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/google/go-github/v68/github"
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +32,10 @@ var (
 )
 
 func doProv(prevAttPath, commit, prevCommit, owner, repo, branch string) {
-	gh_client := github.NewClient(nil)
+	gh_connection := gh_control.NewGhConnection(owner, repo, branch)
 	ctx := context.Background()
-	pa := attest.NewProvenanceAttestor(gh_client, attest.DefaultVerifierOptions)
-	newProv, err := pa.CreateSourceProvenance(ctx, prevAttPath, commit, prevCommit, owner, repo, branch)
+	pa := attest.NewProvenanceAttestor(gh_connection, attest.DefaultVerifierOptions)
+	newProv, err := pa.CreateSourceProvenance(ctx, prevAttPath, commit, prevCommit)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -117,7 +117,8 @@ func convertLineToProv(line string) (*spb.Statement, error) {
 	}
 
 	// Did they give us the provenance as a sigstore bundle?
-	vr, err := Verify(line)
+	// TODO: Allow the user to specify verifier options at the command line.
+	vr, err := Verify(line, DefaultVerifierOptions)
 	if err == nil {
 		// This is it.
 		return vr.Statement, nil
@@ -125,7 +126,7 @@ func convertLineToProv(line string) (*spb.Statement, error) {
 		log.Printf("Line %s is not a sigstore bundle: %v", line, err)
 	}
 
-	return nil, errors.New("Could not convert line to statement.")
+	return nil, errors.New("could not convert line to statement.")
 }
 
 func getPrevProvenance(prevAttPath, prevCommit string) (*spb.Statement, error) {

--- a/sourcetool/pkg/attest/verify.go
+++ b/sourcetool/pkg/attest/verify.go
@@ -1,21 +1,31 @@
 package attest
 
 import (
-	"log"
-
 	"github.com/carabiner-dev/bnd/pkg/bnd"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 )
 
-func Verify(data string) (*verify.VerificationResult, error) {
+type VerificationOptions struct {
+	ExpectedIssuer string
+	ExpectedSan    string
+}
+
+// TODO: Update ExpectedSan to support regex so we can get the branches/tags we really think
+// folks should be using (they won't all run from main).
+var DefaultVerifierOptions = VerificationOptions{
+	ExpectedIssuer: "https://token.actions.githubusercontent.com",
+	ExpectedSan:    "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/create_slsa_source_vsa.yml@refs/heads/main",
+}
+
+func Verify(data string, options VerificationOptions) (*verify.VerificationResult, error) {
 	// TODO: There's more for us to do here... but what?
 	// Maybe check to make sure it's from the identity we expect (the workflow?)
 	verifier := bnd.NewVerifier()
-	verifier.Options.SkipIdentityCheck = true
+	verifier.Options.ExpectedIssuer = options.ExpectedIssuer
+	verifier.Options.ExpectedSan = options.ExpectedSan
 	vr, err := verifier.VerifyInlineBundle([]byte(data))
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("sig %v\n", vr.Signature)
 	return vr, nil
 }

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -10,14 +10,15 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/sign"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/util"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
 	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func CreateUnsignedSourceVsa(owner string, repo string, commit string, sourceLevel string) (string, error) {
-	resourceUri := fmt.Sprintf("git+https://github.com/%s/%s", owner, repo)
+func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, sourceLevel string) (string, error) {
+	resourceUri := fmt.Sprintf("git+https://github.com/%s/%s", gh_connection.Owner, gh_connection.Repo)
 	vsaPred := &vpb.VerificationSummary{
 		Verifier: &vpb.VerificationSummary_Verifier{
 			Id: "https://github.com/slsa-framework/slsa-source-poc"},
@@ -34,6 +35,7 @@ func CreateUnsignedSourceVsa(owner string, repo string, commit string, sourceLev
 		return "", err
 	}
 
+	// TODO: add branch annotation to sub
 	sub := []*spb.ResourceDescriptor{{
 		Digest: map[string]string{"gitCommit": commit},
 	}}
@@ -104,8 +106,8 @@ func getSigningOpts(oidcToken string) (sign.BundleOptions, error) {
 
 // NOTE: This is experimental, and definitely not done.  There's no way for folks to verify
 // what this produces.
-func CreateSignedSourceVsa(owner string, repo string, commit string, sourceLevel string) (string, error) {
-	unsignedVsa, err := CreateUnsignedSourceVsa(owner, repo, commit, sourceLevel)
+func CreateSignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, sourceLevel string) (string, error) {
+	unsignedVsa, err := CreateUnsignedSourceVsa(gh_connection, commit, sourceLevel)
 	if err != nil {
 		return "", err
 	}

--- a/sourcetool/pkg/gh_control/connection.go
+++ b/sourcetool/pkg/gh_control/connection.go
@@ -1,0 +1,18 @@
+package gh_control
+
+import (
+	"github.com/google/go-github/v68/github"
+)
+
+type GitHubConnection struct {
+	Client              *github.Client
+	Owner, Repo, Branch string
+}
+
+func NewGhConnection(owner, repo, branch string) *GitHubConnection {
+	return &GitHubConnection{
+		Client: github.NewClient(nil),
+		Owner:  owner,
+		Repo:   repo,
+		Branch: branch}
+}


### PR DESCRIPTION
Verify the identify of attestation issuers

* Defaults to the expected values when running our reusable workflow.
* Allows users to override these values at the command line (for local testing)
* Refactored a bunch of stuff to be more OO so we don't have to pass so
   many parameters individually.