### PR TITLE
add the policy path we evaluated

### DIFF
--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -63,13 +63,13 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 	}
 
 	// check p against policy
-	level, err := policy.EvaluateProv(ctx, gh_connection, p)
+	level, policyPath, err := policy.EvaluateProv(ctx, gh_connection, p)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// create vsa
-	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, checkLevelProvArgs.commit, level)
+	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, checkLevelProvArgs.commit, level, policyPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -11,15 +11,14 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, sourceLevel string) (string, error) {
+func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, sourceLevel string, policy string) (string, error) {
 	resourceUri := fmt.Sprintf("git+https://github.com/%s/%s", gh_connection.Owner, gh_connection.Repo)
 	vsaPred := &vpb.VerificationSummary{
 		Verifier: &vpb.VerificationSummary_Verifier{
 			Id: "https://github.com/slsa-framework/slsa-source-poc"},
-		TimeVerified: timestamppb.Now(),
-		ResourceUri:  resourceUri,
-		Policy: &vpb.VerificationSummary_Policy{
-			Uri: "https://github.com/slsa-framework/slsa-source-poc/POLICY.md"},
+		TimeVerified:       timestamppb.Now(),
+		ResourceUri:        resourceUri,
+		Policy:             &vpb.VerificationSummary_Policy{Uri: policy},
 		VerificationResult: "PASSED",
 		VerifiedLevels:     []string{sourceLevel},
 	}
@@ -57,15 +56,4 @@ func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit 
 		return "", err
 	}
 	return string(statement), nil
-}
-
-// NOTE: This is experimental, and definitely not done.  There's no way for folks to verify
-// what this produces.
-func CreateSignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, sourceLevel string) (string, error) {
-	unsignedVsa, err := CreateUnsignedSourceVsa(gh_connection, commit, sourceLevel)
-	if err != nil {
-		return "", err
-	}
-
-	return Sign(unsignedVsa)
 }

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -44,40 +44,40 @@ func getPolicyRepoPath(pathToClone string, gh_connection *gh_control.GitHubConne
 	return fmt.Sprintf("%s/%s", pathToClone, getPolicyPath(gh_connection))
 }
 
-func getRemotePolicy(ctx context.Context, gh_connection *gh_control.GitHubConnection) (*RepoPolicy, error) {
+func getRemotePolicy(ctx context.Context, gh_connection *gh_control.GitHubConnection) (*RepoPolicy, string, error) {
 	path := getPolicyPath(gh_connection)
 
 	policyContents, _, _, err := gh_connection.Client.Repositories.GetContents(ctx, SourcePolicyRepoOwner, SourcePolicyRepo, path, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	content, err := policyContents.GetContent()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	var p RepoPolicy
 	err = json.Unmarshal([]byte(content), &p)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return &p, nil
+	return &p, *policyContents.HTMLURL, nil
 }
 
 // Gets the policy for the indicated branch direct from the GitHub repo.
-func GetBranchPolicy(ctx context.Context, gh_connection *gh_control.GitHubConnection) (*ProtectedBranch, error) {
-	p, err := getRemotePolicy(ctx, gh_connection)
+func GetBranchPolicy(ctx context.Context, gh_connection *gh_control.GitHubConnection) (*ProtectedBranch, string, error) {
+	p, path, err := getRemotePolicy(ctx, gh_connection)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	for _, pb := range p.ProtectedBranches {
 		if pb.Name == gh_connection.Branch {
-			return &pb, nil
+			return &pb, path, nil
 		}
 	}
 
-	return nil, errors.New(fmt.Sprintf("Could not find rule for branch %s", gh_connection.Branch))
+	return nil, "", fmt.Errorf("could not find rule for branch %s", gh_connection.Branch)
 }
 
 // Check to see if the local directory is a clean clone or not
@@ -96,7 +96,7 @@ func checkLocalDir(ctx context.Context, gh_connection *gh_control.GitHubConnecti
 		return err
 	}
 	if !status.IsClean() {
-		return errors.New(fmt.Sprintf("You must run this command in a clean clone of %s", SourcePolicyUri))
+		return fmt.Errorf("You must run this command in a clean clone of %s", SourcePolicyUri)
 	}
 
 	path := getPolicyRepoPath(pathToClone, gh_connection)
@@ -108,14 +108,14 @@ func checkLocalDir(ctx context.Context, gh_connection *gh_control.GitHubConnecti
 			return err
 		}
 	} else {
-		return errors.New(fmt.Sprintf("Policy already exists at %s", path))
+		return fmt.Errorf("Policy already exists at %s", path)
 	}
 
 	// Is there a remote policy?
 	// TODO: Look for errors that _aren't_ 404.
-	rp, _ := getRemotePolicy(ctx, gh_connection)
+	rp, _, _ := getRemotePolicy(ctx, gh_connection)
 	if rp != nil {
-		return errors.New(fmt.Sprintf("Policy already exists remotely for %s", getPolicyPath(gh_connection)))
+		return fmt.Errorf("Policy already exists remotely for %s", getPolicyPath(gh_connection))
 	}
 	return nil
 }
@@ -157,59 +157,59 @@ func CreateLocalPolicy(ctx context.Context, gh_connection *gh_control.GitHubConn
 	return path, nil
 }
 
-// Evaluates the control against the policy and returns the resulting source level.
-func EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnection, pushTime time.Time, controlStatus *gh_control.GhControlStatus) (string, error) {
+// Evaluates the control against the policy and returns the resulting source level and policy path.
+func EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnection, controlStatus *gh_control.GhControlStatus) (string, string, error) {
 	// We want to check to ensure the repo hasn't enabled/disabled the rules since
 	// setting the 'since' field in their policy.
-	branchPolicy, err := GetBranchPolicy(ctx, gh_connection)
+	branchPolicy, policyPath, err := GetBranchPolicy(ctx, gh_connection)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	if pushTime.Before(branchPolicy.Since) {
+	if controlStatus.CommitPushTime.Before(branchPolicy.Since) {
 		// This commit was pushed before they had an explicit policy.
-		return slsa_types.SlsaSourceLevel1, nil
+		return slsa_types.SlsaSourceLevel1, policyPath, nil
 	}
 
 	// The control needs to have been enabled for at least as long as the policy says.
 	if branchPolicy.Since.Before(controlStatus.ControlLevelSince) {
 		if branchPolicy.TargetSlsaSourceLevel != slsa_types.SlsaSourceLevel1 {
-			return "", errors.New(fmt.Sprintf("Policy sets target level %s, but control only qualifies for %s", branchPolicy.TargetSlsaSourceLevel, slsa_types.SlsaSourceLevel1))
+			return "", "", fmt.Errorf("Policy sets target level %s, but control only qualifies for %s", branchPolicy.TargetSlsaSourceLevel, slsa_types.SlsaSourceLevel1)
 		}
 
 		// Level 1 doesn't really require any controls.
-		return slsa_types.SlsaSourceLevel1, nil
+		return slsa_types.SlsaSourceLevel1, policyPath, nil
 	}
 
 	// Seems fine, so they get whatever the control status is.
 	// TODO: should we cap them at whatever the policies target is?
-	return controlStatus.ControlLevel, nil
+	return controlStatus.ControlLevel, policyPath, nil
 }
 
-// Evaluates the provenance against the policy and returns the resulting source level
-func EvaluateProv(ctx context.Context, gh_connection *gh_control.GitHubConnection, prov *spb.Statement) (string, error) {
-	branchPolicy, err := GetBranchPolicy(ctx, gh_connection)
+// Evaluates the provenance against the policy and returns the resulting source level and policy path
+func EvaluateProv(ctx context.Context, gh_connection *gh_control.GitHubConnection, prov *spb.Statement) (string, string, error) {
+	branchPolicy, policyPath, err := GetBranchPolicy(ctx, gh_connection)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	provPred, err := attest.GetProvPred(prov)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	levelProp, ok := provPred.Properties[branchPolicy.TargetSlsaSourceLevel]
 	if !ok {
 		// Error, or do we take the min?
-		return "", errors.New(fmt.Sprintf("target level %s not found in provenance %v", branchPolicy.TargetSlsaSourceLevel, provPred))
+		return "", "", fmt.Errorf("target level %s not found in provenance %v", branchPolicy.TargetSlsaSourceLevel, provPred)
 	}
 
 	// Unlike the control only approach, the provenance approach doesn't care how long GitHub claims the control
 	// was in place. The only thing that matters is how long the provenance claims it was in place.
 	if branchPolicy.Since.Before(levelProp.Since) {
-		return "", errors.New(fmt.Sprintf("level %s only in effect since %v, policy requires it since at least %v", branchPolicy.TargetSlsaSourceLevel, levelProp.Since, branchPolicy.Since))
+		return "", "", fmt.Errorf("level %s only in effect since %v, policy requires it since at least %v", branchPolicy.TargetSlsaSourceLevel, levelProp.Since, branchPolicy.Since)
 	}
 
 	// Looks good!
-	return branchPolicy.TargetSlsaSourceLevel, nil
+	return branchPolicy.TargetSlsaSourceLevel, policyPath, nil
 }


### PR DESCRIPTION
Instead of linking to POLICY.md the VSA now lists the path the policy we evaluated.

```json
{
  "_type": "https://in-toto.io/Statement/v1",
  "subject": [
    {
      "digest": {
        "gitCommit": "6efc0a710cb413aa4aa2d53ad75411a599fb2db1"
      },
      "annotations": {
        "source_branches": [
          "refs/heads/main"
        ]
      }
    }
  ],
  "predicateType": "https://slsa.dev/verification_summary/v1",
  "predicate": {
    "policy": {
      "uri": "https://github.com/slsa-framework/slsa-source-poc/blob/main/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json"
    },
    "resourceUri": "git+https://github.com/slsa-framework/slsa-source-poc",
    "timeVerified": "2025-02-24T16:05:52.794893360Z",
    "verificationResult": "PASSED",
    "verifiedLevels": [
      "SLSA_SOURCE_LEVEL_3"
    ],
    "verifier": {
      "id": "https://github.com/slsa-framework/slsa-source-poc"
    }
  }
}
```