### PR TITLE
add repo uri to provenance

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -139,13 +139,14 @@ Source provenance:
     "activity_type": "pr_merge",
     "actor": "TomHennen",
     "branch": "refs/heads/main",
-    "created_on": "2025-02-24T15:27:47.179656547Z",
+    "created_on": "2025-02-24T16:14:11.497058337Z",
     "prev_commit": "a552404f404933e685daa6f1d189127cef49aa90",
     "properties": {
       "SLSA_SOURCE_LEVEL_3": {
         "since": "2025-02-24T15:24:23.245811209Z"
       }
-    }
+    },
+    "repo_uri": "https://github.com/slsa-framework/slsa-source-poc"
   }
 }
 ```

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -31,6 +31,7 @@ const SourceProvPredicateType = "https://github.com/slsa-framework/slsa-source-p
 type SourceProvenancePred struct {
 	// The commit preceding 'Commit' in the current context.
 	PrevCommit   string    `json:"prev_commit"`
+	RepoUri      string    `json:"repo_uri"`
 	ActivityType string    `json:"activity_type"`
 	Actor        string    `json:"actor"`
 	Branch       string    `json:"branch"`
@@ -122,6 +123,7 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 
 	var curProvPred SourceProvenancePred
 	curProvPred.PrevCommit = prevCommit
+	curProvPred.RepoUri = pa.gh_connection.GetRepoUri()
 	curProvPred.Actor = controlStatus.ActorLogin
 	curProvPred.ActivityType = controlStatus.ActivityType
 	curProvPred.Branch = pa.gh_connection.GetFullBranch()

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -12,7 +12,7 @@ import (
 )
 
 func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, sourceLevel string, policy string) (string, error) {
-	resourceUri := fmt.Sprintf("git+https://github.com/%s/%s", gh_connection.Owner, gh_connection.Repo)
+	resourceUri := fmt.Sprintf("git+%s", gh_connection.GetRepoUri())
 	vsaPred := &vpb.VerificationSummary{
 		Verifier: &vpb.VerificationSummary_Verifier{
 			Id: "https://github.com/slsa-framework/slsa-source-poc"},

--- a/sourcetool/pkg/gh_control/connection.go
+++ b/sourcetool/pkg/gh_control/connection.go
@@ -23,3 +23,8 @@ func NewGhConnection(owner, repo, branch string) *GitHubConnection {
 func (ghc GitHubConnection) GetFullBranch() string {
 	return fmt.Sprintf("refs/heads/%s", ghc.Branch)
 }
+
+// Returns the URI of the repo this connection tracks.
+func (ghc GitHubConnection) GetRepoUri() string {
+	return fmt.Sprintf("https://github.com/%s/%s", ghc.Owner, ghc.Repo)
+}


### PR DESCRIPTION
Source provenance now includes the repository uri

```json
{
  "_type": "https://in-toto.io/Statement/v1",
  "subject": [
    {
      "digest": {
        "gitCommit": "6efc0a710cb413aa4aa2d53ad75411a599fb2db1"
      }
    }
  ],
  "predicateType": "https://github.com/slsa-framework/slsa-source-poc/source-provenance/v1",
  "predicate": {
    "activity_type": "pr_merge",
    "actor": "TomHennen",
    "branch": "refs/heads/main",
    "created_on": "2025-02-24T16:14:11.497058337Z",
    "prev_commit": "a552404f404933e685daa6f1d189127cef49aa90",
    "properties": {
      "SLSA_SOURCE_LEVEL_3": {
        "since": "2025-02-24T15:24:23.245811209Z"
      }
    },
    "repo_uri": "https://github.com/slsa-framework/slsa-source-poc"
  }
}
```