### PR TITLE
Rename POLICY.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,7 +21,7 @@ using GitHub's existing functionality.
 ## SLSA Requirements
 
 For detailed information on how this tool meets the SLSA requirements see
-[POLICY.md](./POLICY.md).
+[REQUIREMENTS_MAPPING.md](./REQUIREMENTS_MAPPING.md).
 
 ## Approaches
 There are two main approaches taken in this proof-of-concept:

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ The code in this repository should not be relied upon for production purposes.
 
 Status: in development
 
-## Policy & Design
+## Design
 
-[POLICY.md](POLICY.md) defines the rationale behind labeling a given commit at a particular SLSA level.
+[REQUIREMENTS_MAPPING.md](REQUIREMENTS_MAPPING.md) defines the rationale for how
+this tool meets the SLSA Source Requirements.
 
-[DESIGN.md](DESIGN.md) explains how the system works.
+[DESIGN.md](DESIGN.md) explains more specifically how the system works.
 
 ## SLSA Source VSAs
 

--- a/REQUIREMENTS_MAPPING.md
+++ b/REQUIREMENTS_MAPPING.md
@@ -1,8 +1,8 @@
-# SLSA Source PoC - Policy
+# SLSA Source PoC - Requirements Mapping
 
 This file describes how this tool comes to a conclusion about what SLSA Source Level a given commit meets.
 
-It is currently written based on https://slsa.dev/spec/draft/source-requirements as of 2024-01-06
+It is currently written based on https://slsa.dev/spec/draft/source-requirements as of 2025-01-06
 
 ## Safe Expunging Process
 


### PR DESCRIPTION
It was getting to confusing to have a policy folder and then also have this markdown file.  By renaming it we can avoid _that_ confusion.