### PR TITLE
Add REVIEW_ENFORCED property to source provenance

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -210,6 +210,20 @@ Specifically, the reusable workflow provides the following guarantees:
 3. It lets us ensure the provenance was created contemporaneously with the
    introduction of the current commit to the current branch.
 
+## Additional Controls
+
+### REVIEW_ENFORCED
+
+This tool can also check to see if the GitHub repo/ref is configured to require
+2-party review.  To do so it checks that the repo:
+
+1. Is configured to require the use of Pull Requests.
+2. That the pull requests rule configures:
+    * Required approvals = 1
+    * "Dismiss stale pull request approvals when new commits are pushed"
+    * "Require review from Code Owners"
+    * "Require approval of the most recent reviewable push"
+
 ## Open Issues
 
 ### Dealing with reliability

--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -54,7 +54,7 @@ func doCheckLevel(commit, owner, repo, branch, outputVsa, outputUnsignedVsa stri
 	}
 	fmt.Print(level)
 
-	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, commit, controlStatus.ControlLevel, policyPath)
+	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, commit, level, policyPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -132,8 +132,8 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 	levelProp := SourceProvenanceProperty{Since: curTime}
 	curProvPred.Properties[controlStatus.SlsaLevelControl.Level] = levelProp
 
-	if controlStatus.RequiresReview {
-		levelProp = SourceProvenanceProperty{Since: controlStatus.RequiresReviewSince}
+	if controlStatus.ReviewControl.RequiresReview {
+		levelProp = SourceProvenanceProperty{Since: controlStatus.ReviewControl.EnabledSince}
 		curProvPred.Properties[slsa_types.ReviewEnforced] = levelProp
 	}
 

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -132,6 +132,11 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 	levelProp := SourceProvenanceProperty{Since: curTime}
 	curProvPred.Properties[controlStatus.ControlLevel] = levelProp
 
+	if controlStatus.RequiresReview {
+		levelProp = SourceProvenanceProperty{Since: controlStatus.RequiresReviewSince}
+		curProvPred.Properties[slsa_types.ReviewEnforced] = levelProp
+	}
+
 	return addPredToStatement(&curProvPred, commit)
 }
 

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -115,8 +115,8 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 	// The only requirement needed for level 3, beyond the level 2 requirements
 	// (in this implementation) is _source provenance_.  Since that's what we're
 	// creating here we can upgrade to level 3.
-	if controlStatus.ControlLevel == slsa_types.SlsaSourceLevel2 {
-		controlStatus.ControlLevel = slsa_types.SlsaSourceLevel3
+	if controlStatus.SlsaLevelControl.Level == slsa_types.SlsaSourceLevel2 {
+		controlStatus.SlsaLevelControl.Level = slsa_types.SlsaSourceLevel3
 	}
 
 	curTime := time.Now()
@@ -130,7 +130,7 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 	curProvPred.CreatedOn = curTime
 	curProvPred.Properties = make(map[string]SourceProvenanceProperty)
 	levelProp := SourceProvenanceProperty{Since: curTime}
-	curProvPred.Properties[controlStatus.ControlLevel] = levelProp
+	curProvPred.Properties[controlStatus.SlsaLevelControl.Level] = levelProp
 
 	if controlStatus.RequiresReview {
 		levelProp = SourceProvenanceProperty{Since: controlStatus.RequiresReviewSince}

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, sourceLevel string, policy string) (string, error) {
+func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, level string, policy string) (string, error) {
 	resourceUri := fmt.Sprintf("git+%s", gh_connection.GetRepoUri())
 	vsaPred := &vpb.VerificationSummary{
 		Verifier: &vpb.VerificationSummary_Verifier{
@@ -20,7 +20,7 @@ func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit 
 		ResourceUri:        resourceUri,
 		Policy:             &vpb.VerificationSummary_Policy{Uri: policy},
 		VerificationResult: "PASSED",
-		VerifiedLevels:     []string{sourceLevel},
+		VerifiedLevels:     []string{level},
 	}
 
 	predJson, err := protojson.Marshal(vsaPred)

--- a/sourcetool/pkg/gh_control/checklevel.go
+++ b/sourcetool/pkg/gh_control/checklevel.go
@@ -60,18 +60,21 @@ type SlsaLevelControl struct {
 	EnabledSince time.Time
 }
 
+type ReviewControl struct {
+	RequiresReview bool
+	EnabledSince   time.Time
+}
+
 type GhControlStatus struct {
 	// The SLSA Source Level the _controls_ in this repo meet.
 	SlsaLevelControl SlsaLevelControl
+	ReviewControl    ReviewControl
 	// The time the commit we're evaluating was pushed.
 	CommitPushTime time.Time
 	// The actor that pushed the commit.
 	ActorLogin string
 	// The type of activity that created the commit.
 	ActivityType string
-	// True if the branch requires review
-	RequiresReview      bool
-	RequiresReviewSince time.Time
 }
 
 func (ghc *GitHubConnection) ruleMeetsRequiresReview(rule *github.PullRequestBranchRule) bool {
@@ -98,8 +101,8 @@ func (ghc *GitHubConnection) populateRequiresReview(ctx context.Context, rules [
 	}
 
 	if oldestActive != nil {
-		controlStatus.RequiresReview = true
-		controlStatus.RequiresReviewSince = oldestActive.UpdatedAt.Time
+		controlStatus.ReviewControl.RequiresReview = true
+		controlStatus.ReviewControl.EnabledSince = oldestActive.UpdatedAt.Time
 	}
 
 	return nil

--- a/sourcetool/pkg/gh_control/checklevel.go
+++ b/sourcetool/pkg/gh_control/checklevel.go
@@ -55,11 +55,14 @@ func (ghc *GitHubConnection) commitActivity(ctx context.Context, commit string) 
 	return nil, fmt.Errorf("could not find repo activity for commit %s", commit)
 }
 
+type SlsaLevelControl struct {
+	Level        string
+	EnabledSince time.Time
+}
+
 type GhControlStatus struct {
 	// The SLSA Source Level the _controls_ in this repo meet.
-	ControlLevel string
-	// The time the control has been enabled since.
-	ControlLevelSince time.Time
+	SlsaLevelControl SlsaLevelControl
 	// The time the commit we're evaluating was pushed.
 	CommitPushTime time.Time
 	// The actor that pushed the commit.
@@ -132,11 +135,12 @@ func (ghc *GitHubConnection) DetermineSourceLevelControlOnly(ctx context.Context
 
 	controlStatus := GhControlStatus{
 		// Default to L1, but upgrade later if possible.
-		ControlLevel:      slsa_types.SlsaSourceLevel1,
-		ControlLevelSince: time.Time{},
-		CommitPushTime:    activity.Timestamp,
-		ActivityType:      activity.ActivityType,
-		ActorLogin:        activity.Actor.Login}
+		SlsaLevelControl: SlsaLevelControl{
+			Level:        slsa_types.SlsaSourceLevel1,
+			EnabledSince: time.Time{}},
+		CommitPushTime: activity.Timestamp,
+		ActivityType:   activity.ActivityType,
+		ActorLogin:     activity.Actor.Login}
 
 	rules, _, err := ghc.Client.Repositories.GetRulesForBranch(ctx, ghc.Owner, ghc.Repo, ghc.Branch)
 
@@ -171,8 +175,8 @@ func (ghc *GitHubConnection) DetermineSourceLevelControlOnly(ctx context.Context
 	}
 
 	// All the rules required for L2 are enabled.
-	controlStatus.ControlLevel = slsa_types.SlsaSourceLevel2
-	controlStatus.ControlLevelSince = newestRule.UpdatedAt.Time
+	controlStatus.SlsaLevelControl.Level = slsa_types.SlsaSourceLevel2
+	controlStatus.SlsaLevelControl.EnabledSince = newestRule.UpdatedAt.Time
 
 	// Let's get some extra information, like do they require reviews?
 	err = ghc.populateRequiresReview(ctx, rules.PullRequest, &controlStatus)

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -172,7 +172,7 @@ func EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnec
 	}
 
 	// The control needs to have been enabled for at least as long as the policy says.
-	if branchPolicy.Since.Before(controlStatus.ControlLevelSince) {
+	if branchPolicy.Since.Before(controlStatus.SlsaLevelControl.EnabledSince) {
 		if branchPolicy.TargetSlsaSourceLevel != slsa_types.SlsaSourceLevel1 {
 			return "", "", fmt.Errorf("Policy sets target level %s, but control only qualifies for %s", branchPolicy.TargetSlsaSourceLevel, slsa_types.SlsaSourceLevel1)
 		}
@@ -183,7 +183,7 @@ func EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnec
 
 	// Seems fine, so they get whatever the control status is.
 	// TODO: should we cap them at whatever the policies target is?
-	return controlStatus.ControlLevel, policyPath, nil
+	return controlStatus.SlsaLevelControl.Level, policyPath, nil
 }
 
 // Evaluates the provenance against the policy and returns the resulting source level and policy path

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -4,4 +4,5 @@ const (
 	SlsaSourceLevel1 = "SLSA_SOURCE_LEVEL_1"
 	SlsaSourceLevel2 = "SLSA_SOURCE_LEVEL_2"
 	SlsaSourceLevel3 = "SLSA_SOURCE_LEVEL_3"
+	ReviewEnforced   = "REVIEW_ENFORCED"
 )


### PR DESCRIPTION
This checks to see if the revision required review (and how long that control has been in place).

Went with 'ENFORCED' instead of 'REQUIRED' since I didn't want people to be confused and think "Required == 'someone needs to check this revision before it can be used'" when really it means "this revision _was_ reviewed".

For the purposes of this tool it takes an _opinionated_ approach which assumes that the way you achieve this using GitHub controls is to

1. Require the use of Pull Requests.
2. Set:
    * Required approvals = 1
    * "Dismiss stale pull request approvals when new commits are pushed"
    * "Require review from Code Owners"
    * "Require approval of the most recent reviewable push"


Still TODO: embed this information in the VSA.