### PR TITLE
Allow additional controls in policy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -127,7 +127,7 @@ Source provenance indicates:
 
 1. The commit the data applies to
 2. The commit prior to this one
-3. When each of some set of controls (properties) started being enforced.
+3. The set of controls that are enabled and when they started being enforced.
 4. The actor that pushed the commit.
 5. The branch the commit was pushed to.
 6. When the commit was pushed.
@@ -144,18 +144,23 @@ Source provenance indicates:
       }
     }
   ],
-  "predicateType": "https://github.com/slsa-framework/slsa-source-poc/source-provenance/v1",
+  "predicateType": "https://github.com/slsa-framework/slsa-source-poc/source-provenance/v1-draft",
   "predicate": {
     "activity_type": "pr_merge",
     "actor": "TomHennen",
     "branch": "refs/heads/main",
-    "created_on": "2025-02-24T16:14:11.497058337Z",
-    "prev_commit": "a552404f404933e685daa6f1d189127cef49aa90",
-    "properties": {
-      "SLSA_SOURCE_LEVEL_3": {
-        "since": "2025-02-24T15:24:23.245811209Z"
+    "controls": [
+      {
+        "name": "CONTINUITY_ENFORCED",
+        "since": "2025-01-26T02:23:18.106Z"
+      },
+      {
+        "name": "PROVENANCE_AVAILABLE",
+        "since": "2025-03-01T21:28:30.941538615Z"
       }
-    },
+    ],
+    "created_on": "2025-03-01T21:28:30.941538615Z",
+    "prev_commit": "a552404f404933e685daa6f1d189127cef49aa90",
     "repo_uri": "https://github.com/slsa-framework/slsa-source-poc"
   }
 }

--- a/REQUIREMENTS_MAPPING.md
+++ b/REQUIREMENTS_MAPPING.md
@@ -37,15 +37,7 @@ TODO: Now enabling people to set a canonical location in a policy file.  Not yet
 
 ### Distribute summary attestations
 
-This tool stores summary attestations as `git notes`.
-
-To display attestations:
-
-1. Clone the repo in question
-2. `git fetch origin "refs/notes/*:refs/notes/*"`
-3. `git notes show <COMMIT> | jq -r .payload | base64 --decode | jq`
-
-NOTE: This **does not** verify the signature at all.  That work is TBD.
+This tool stores summary attestations with other attestations in `git notes`, one attestation per line.
 
 ### Distribute provenance attestations
 
@@ -55,13 +47,7 @@ Level 2: N/A
 
 Level 3:
 
-This tool stores provenance attestations (with summary attestations) as `git notes`.
-
-To display attestations:
-
-1. Clone the repo in question
-2. `git fetch origin "refs/notes/*:refs/notes/*"`
-3. `git notes show <COMMIT> | jq -r .payload | base64 --decode | jq`
+This tool stores provenance attestations with other attestations in `git notes`, one attestation per line.
 
 ## Source Control System Requirements
 
@@ -86,13 +72,7 @@ Open question: Is this duplicative of "Revisions are immutable and uniquely iden
 
 Level 1+: This is the tool that is generating these summary attestations.
 
-This tool stores summary attestations (with provenance attestations) as `git notes`.
-
-To display attestations:
-
-1. Clone the repo in question
-2. `git fetch origin "refs/notes/*:refs/notes/*"`
-3. `git notes show <COMMIT> | jq -r .payload | base64 --decode | jq`
+This tool stores summary attestations with other attestations in `git notes`, one attestation per line.
 
 Open question: Is this duplicative of "Distribute summary attestations"
 

--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -48,13 +48,13 @@ func doCheckLevel(commit, owner, repo, branch, outputVsa, outputUnsignedVsa stri
 	if err != nil {
 		log.Fatal(err)
 	}
-	level, policyPath, err := policy.EvaluateControl(ctx, gh_connection, controlStatus)
+	verifiedLevels, policyPath, err := policy.EvaluateControl(ctx, gh_connection, controlStatus)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Print(level)
+	fmt.Print(verifiedLevels)
 
-	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, commit, level, policyPath)
+	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, commit, verifiedLevels, policyPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -63,13 +63,13 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 	}
 
 	// check p against policy
-	level, policyPath, err := policy.EvaluateProv(ctx, gh_connection, p)
+	verifiedLevels, policyPath, err := policy.EvaluateProv(ctx, gh_connection, p)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// create vsa
-	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, checkLevelProvArgs.commit, level, policyPath)
+	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection, checkLevelProvArgs.commit, verifiedLevels, policyPath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 		log.Printf("unsigned prov: %s\n", unsignedProv)
 		log.Printf("unsigned vsa: %s\n", unsignedVsa)
 	}
-	fmt.Print(level)
+	fmt.Print(verifiedLevels)
 }
 
 func init() {

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -6,12 +6,13 @@ import (
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	spb "github.com/in-toto/attestation/go/v1"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa_types"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, level string, policy string) (string, error) {
+func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit string, verifiedLevels slsa_types.SourceVerifiedLevels, policy string) (string, error) {
 	resourceUri := fmt.Sprintf("git+%s", gh_connection.GetRepoUri())
 	vsaPred := &vpb.VerificationSummary{
 		Verifier: &vpb.VerificationSummary_Verifier{
@@ -20,7 +21,7 @@ func CreateUnsignedSourceVsa(gh_connection *gh_control.GitHubConnection, commit 
 		ResourceUri:        resourceUri,
 		Policy:             &vpb.VerificationSummary_Policy{Uri: policy},
 		VerificationResult: "PASSED",
-		VerifiedLevels:     []string{level},
+		VerifiedLevels:     verifiedLevels,
 	}
 
 	predJson, err := protojson.Marshal(vsaPred)

--- a/sourcetool/pkg/gh_control/checklevel.go
+++ b/sourcetool/pkg/gh_control/checklevel.go
@@ -86,7 +86,7 @@ func (ghc *GitHubConnection) computeContinuityControl(ctx context.Context, commi
 	}
 
 	if oldestDeletion == nil || oldestNoFf == nil {
-		log.Printf("oldestDeletion (%v) or oldestNoFastForward (%v) is nil, cannot be L2+", oldestDeletion, oldestNoFf)
+		log.Printf("oldestDeletion (%v) or oldestNoFf (%v) is nil, cannot be L2+", oldestDeletion, oldestNoFf)
 		return nil, nil
 	}
 
@@ -101,7 +101,6 @@ func (ghc *GitHubConnection) computeContinuityControl(ctx context.Context, commi
 		return nil, fmt.Errorf("commit %s created before (%v) the rule was enabled (%v), that shouldn't happen", commit, activity.Timestamp, newestRule.UpdatedAt.Time)
 	}
 
-	// All the rules required for L2 are enabled.
 	return &slsa_types.Control{Name: slsa_types.ContinuityEnforced, Since: newestRule.UpdatedAt.Time}, nil
 }
 

--- a/sourcetool/pkg/gh_control/checklevel.go
+++ b/sourcetool/pkg/gh_control/checklevel.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v69/github"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa_types"
 )
 
 type actor struct {
@@ -53,25 +54,16 @@ func (ghc *GitHubConnection) commitActivity(ctx context.Context, commit string) 
 	return nil, fmt.Errorf("could not find repo activity for commit %s", commit)
 }
 
-type ContinuityControl struct {
-	RequiresContinuity bool
-	EnabledSince       time.Time
-}
-
-type ReviewControl struct {
-	RequiresReview bool
-	EnabledSince   time.Time
-}
-
 type GhControlStatus struct {
-	ContinuityControl ContinuityControl
-	ReviewControl     ReviewControl
 	// The time the commit we're evaluating was pushed.
 	CommitPushTime time.Time
 	// The actor that pushed the commit.
 	ActorLogin string
 	// The type of activity that created the commit.
 	ActivityType string
+	// The controls that are enabled according to the GitHub API.
+	// May not include other controls like if we have provenance.
+	Controls slsa_types.Controls
 }
 
 func (ghc *GitHubConnection) ruleMeetsRequiresReview(rule *github.PullRequestBranchRule) bool {
@@ -81,20 +73,21 @@ func (ghc *GitHubConnection) ruleMeetsRequiresReview(rule *github.PullRequestBra
 		rule.Parameters.RequireLastPushApproval
 }
 
-func (ghc *GitHubConnection) computeContinuityControl(ctx context.Context, commit string, rules *github.BranchRules, activity *activity) (ContinuityControl, error) {
+// Computes the continuity control returning nil if it's not enabled.
+func (ghc *GitHubConnection) computeContinuityControl(ctx context.Context, commit string, rules *github.BranchRules, activity *activity) (*slsa_types.Control, error) {
 	oldestDeletion, err := ghc.getOldestActiveRule(ctx, rules.Deletion)
 	if err != nil {
-		return ContinuityControl{}, err
+		return nil, err
 	}
 
 	oldestNoFf, err := ghc.getOldestActiveRule(ctx, rules.NonFastForward)
 	if err != nil {
-		return ContinuityControl{}, err
+		return nil, err
 	}
 
 	if oldestDeletion == nil || oldestNoFf == nil {
 		log.Printf("oldestDeletion (%v) or oldestNoFastForward (%v) is nil, cannot be L2+", oldestDeletion, oldestNoFf)
-		return ContinuityControl{RequiresContinuity: false, EnabledSince: time.Time{}}, nil
+		return nil, nil
 	}
 
 	newestRule := oldestDeletion
@@ -105,20 +98,21 @@ func (ghc *GitHubConnection) computeContinuityControl(ctx context.Context, commi
 	// Check that the commit was created after the newest rule was enabled...
 	// to be sure folks aren't somehow sneaking something through...
 	if activity.Timestamp.Before(newestRule.UpdatedAt.Time) {
-		return ContinuityControl{}, fmt.Errorf("commit %s created before (%v) the rule was enabled (%v), that shouldn't happen", commit, activity.Timestamp, newestRule.UpdatedAt.Time)
+		return nil, fmt.Errorf("commit %s created before (%v) the rule was enabled (%v), that shouldn't happen", commit, activity.Timestamp, newestRule.UpdatedAt.Time)
 	}
 
 	// All the rules required for L2 are enabled.
-	return ContinuityControl{RequiresContinuity: true, EnabledSince: newestRule.UpdatedAt.Time}, nil
+	return &slsa_types.Control{Name: slsa_types.ContinuityEnforced, Since: newestRule.UpdatedAt.Time}, nil
 }
 
-func (ghc *GitHubConnection) computeReviewControl(ctx context.Context, rules []*github.PullRequestBranchRule) (ReviewControl, error) {
+// Computes the review control returning nil if it's not enabled.
+func (ghc *GitHubConnection) computeReviewControl(ctx context.Context, rules []*github.PullRequestBranchRule) (*slsa_types.Control, error) {
 	var oldestActive *github.RepositoryRuleset
 	for _, rule := range rules {
 		if ghc.ruleMeetsRequiresReview(rule) {
 			ruleset, _, err := ghc.Client.Repositories.GetRuleset(ctx, ghc.Owner, ghc.Repo, rule.RulesetID, false)
 			if err != nil {
-				return ReviewControl{}, err
+				return nil, err
 			}
 			if ruleset.Enforcement == "active" {
 				if oldestActive == nil || oldestActive.UpdatedAt.Time.After(ruleset.UpdatedAt.Time) {
@@ -129,10 +123,10 @@ func (ghc *GitHubConnection) computeReviewControl(ctx context.Context, rules []*
 	}
 
 	if oldestActive != nil {
-		return ReviewControl{RequiresReview: true, EnabledSince: oldestActive.UpdatedAt.Time}, nil
+		return &slsa_types.Control{Name: slsa_types.ReviewEnforced, Since: oldestActive.UpdatedAt.Time}, nil
 	}
 
-	return ReviewControl{}, nil
+	return nil, nil
 }
 
 func (ghc *GitHubConnection) getOldestActiveRule(ctx context.Context, rules []*github.BranchRuleMetadata) (*github.RepositoryRuleset, error) {
@@ -164,13 +158,10 @@ func (ghc *GitHubConnection) DetermineSourceLevelControlOnly(ctx context.Context
 	}
 
 	controlStatus := GhControlStatus{
-		// Assume continuity isn't required until we find otherwise.
-		ContinuityControl: ContinuityControl{
-			RequiresContinuity: false,
-			EnabledSince:       time.Time{}},
 		CommitPushTime: activity.Timestamp,
 		ActivityType:   activity.ActivityType,
-		ActorLogin:     activity.Actor.Login}
+		ActorLogin:     activity.Actor.Login,
+		Controls:       slsa_types.Controls{}}
 
 	rules, _, err := ghc.Client.Repositories.GetRulesForBranch(ctx, ghc.Owner, ghc.Repo, ghc.Branch)
 
@@ -179,15 +170,17 @@ func (ghc *GitHubConnection) DetermineSourceLevelControlOnly(ctx context.Context
 	}
 
 	// Compute the controls enforced.
-	controlStatus.ContinuityControl, err = ghc.computeContinuityControl(ctx, commit, rules, activity)
+	continuityControl, err := ghc.computeContinuityControl(ctx, commit, rules, activity)
 	if err != nil {
 		return nil, fmt.Errorf("could not populate ContinuityControl: %w", err)
 	}
+	controlStatus.Controls.AddControl(continuityControl)
 
-	controlStatus.ReviewControl, err = ghc.computeReviewControl(ctx, rules.PullRequest)
+	reviewControl, err := ghc.computeReviewControl(ctx, rules.PullRequest)
 	if err != nil {
 		return nil, fmt.Errorf("could not populate ReviewControl: %w", err)
 	}
+	controlStatus.Controls.AddControl(reviewControl)
 
 	return &controlStatus, nil
 }

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -1,8 +1,17 @@
 package slsa_types
 
+type SlsaSourceLevelData struct {
+	LevelName string
+	LevelNum  int
+}
+
+type SlsaSourceLevel *SlsaSourceLevelData
+
 const (
-	SlsaSourceLevel1 = "SLSA_SOURCE_LEVEL_1"
-	SlsaSourceLevel2 = "SLSA_SOURCE_LEVEL_2"
-	SlsaSourceLevel3 = "SLSA_SOURCE_LEVEL_3"
-	ReviewEnforced   = "REVIEW_ENFORCED"
+	SlsaSourceLevel1    = "SLSA_SOURCE_LEVEL_1"
+	SlsaSourceLevel2    = "SLSA_SOURCE_LEVEL_2"
+	SlsaSourceLevel3    = "SLSA_SOURCE_LEVEL_3"
+	ContinuityEnforced  = "CONTINUITY_ENFORCED"
+	ProvenanceAvailable = "PROVENANCE_AVAILABLE"
+	ReviewEnforced      = "REVIEW_ENFORCED"
 )

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -45,3 +45,5 @@ func (controls Controls) GetControl(name string) *Control {
 	}
 	return nil
 }
+
+type SourceVerifiedLevels []string

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -1,5 +1,7 @@
 package slsa_types
 
+import "time"
+
 type SlsaSourceLevelData struct {
 	LevelName string
 	LevelNum  int
@@ -15,3 +17,31 @@ const (
 	ProvenanceAvailable = "PROVENANCE_AVAILABLE"
 	ReviewEnforced      = "REVIEW_ENFORCED"
 )
+
+type Control struct {
+	// The name of the control
+	Name string `json:"name"`
+	// The time from which this control has been continuously enforced/observed.
+	Since time.Time `json:"since"`
+}
+
+type Controls []Control
+
+// Adds the control to the list. Ignores nil controls.
+// Does not check for duplicate controls.
+func (controls *Controls) AddControl(control *Control) {
+	if control == nil {
+		return
+	}
+	*controls = append(*controls, *control)
+}
+
+// Gets the control with the corresponding name, returns nil if not found.
+func (controls Controls) GetControl(name string) *Control {
+	for _, control := range controls {
+		if control.Name == name {
+			return &control
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The tool now allows additional controls to be enforced via policy.

It also enables reflecting these things within the VSA.

* Refactored provenance to store a list of 'controls' instead of a map of properties.
* Provenance no longer lists the SLSA Level directly (that's left to the VSA).  This prevents misinterpretation, simplifies other logic, and makes it easier to 'relax' policy if desired.
* provenance and GhControlStatus use the same 'type' for controls, simplifying logic.
* Policies can require two party review, and if so REVIEW_ENFORCED will be added to the VSA
* Changed source provenance type to `-draft` since its still in flux.