### PR TITLE
Make policy easier to deal with

### DIFF
--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -17,7 +17,7 @@ import (
 )
 
 type CheckLevelArgs struct {
-	commit, owner, repo, branch, outputVsa, outputUnsignedVsa string
+	commit, owner, repo, branch, outputVsa, outputUnsignedVsa, useLocalPolicy string
 }
 
 // checklevelCmd represents the checklevel command
@@ -48,7 +48,9 @@ func doCheckLevel(commit, owner, repo, branch, outputVsa, outputUnsignedVsa stri
 	if err != nil {
 		log.Fatal(err)
 	}
-	verifiedLevels, policyPath, err := policy.EvaluateControl(ctx, gh_connection, controlStatus)
+	pol := policy.NewPolicy()
+	pol.UseLocalPolicy = checkLevelProvArgs.useLocalPolicy
+	verifiedLevels, policyPath, err := pol.EvaluateControl(ctx, gh_connection, controlStatus)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -89,4 +91,6 @@ func init() {
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.branch, "branch", "", "The branch within the repository - required.")
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.outputVsa, "output_vsa", "", "The path to write a signed VSA with the determined level.")
 	checklevelCmd.Flags().StringVar(&checkLevelArgs.outputUnsignedVsa, "output_unsigned_vsa", "", "The path to write an unsigned vsa with the determined level.")
+	checklevelCmd.Flags().StringVar(&checkLevelArgs.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
+
 }

--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -44,7 +44,7 @@ func doCheckLevel(commit, owner, repo, branch, outputVsa, outputUnsignedVsa stri
 	gh_connection := gh_control.NewGhConnection(owner, repo, branch).WithAuthToken(githubToken)
 	ctx := context.Background()
 
-	controlStatus, err := gh_connection.DetermineSourceLevelControlOnly(ctx, commit)
+	controlStatus, err := gh_connection.GetControls(ctx, commit)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -223,10 +223,7 @@ func (pa ProvenanceAttestor) CreateSourceProvenance(ctx context.Context, prevAtt
 		if prevControl == nil {
 			continue
 		}
-		// Use the oldest Since of the two
-		if prevControl.Since.Before(curControl.Since) {
-			curControl.Since = prevControl.Since
-		}
+		curControl.Since = slsa_types.EarlierTime(curControl.Since, prevControl.Since)
 	}
 
 	return addPredToStatement(curProvPred, commit)

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -102,7 +102,7 @@ func doesSubjectIncludeCommit(statement *spb.Statement, commit string) bool {
 
 // Create provenance for the current commit without any context from the previous provenance (if any).
 func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit, prevCommit string) (*spb.Statement, error) {
-	controlStatus, err := pa.gh_connection.DetermineSourceLevelControlOnly(ctx, commit)
+	controlStatus, err := pa.gh_connection.GetControls(ctx, commit)
 	if err != nil {
 		return nil, err
 	}

--- a/sourcetool/pkg/gh_control/checklevel.go
+++ b/sourcetool/pkg/gh_control/checklevel.go
@@ -144,12 +144,9 @@ func (ghc *GitHubConnection) getOldestActiveRule(ctx context.Context, rules []*g
 	return oldestActive, nil
 }
 
-// Determines the source level using GitHub's built in controls only.
+// Determines the controls that are in place using GitHub's APIs.
 // This is necessarily only as good as GitHub's controls and existing APIs.
-// This is a useful demonstration on how SLSA Level 2 can be achieved with ~minimal effort.
-//
-// Returns the determined source level (level 2 max) or error.
-func (ghc *GitHubConnection) DetermineSourceLevelControlOnly(ctx context.Context, commit string) (*GhControlStatus, error) {
+func (ghc *GitHubConnection) GetControls(ctx context.Context, commit string) (*GhControlStatus, error) {
 	// We want to know when this commit was pushed to ensure the rules were active _then_.
 	activity, err := ghc.commitActivity(ctx, commit)
 	if err != nil {

--- a/sourcetool/pkg/gh_control/connection.go
+++ b/sourcetool/pkg/gh_control/connection.go
@@ -1,6 +1,7 @@
 package gh_control
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-github/v69/github"
@@ -36,4 +37,12 @@ func (ghc *GitHubConnection) GetFullBranch() string {
 // Returns the URI of the repo this connection tracks.
 func (ghc *GitHubConnection) GetRepoUri() string {
 	return fmt.Sprintf("https://github.com/%s/%s", ghc.Owner, ghc.Repo)
+}
+
+func (ghc *GitHubConnection) GetLatestCommit(ctx context.Context) (string, error) {
+	branch, _, err := ghc.Client.Repositories.GetBranch(ctx, ghc.Owner, ghc.Repo, ghc.Branch, 1)
+	if err != nil {
+		return "", fmt.Errorf("could not get info on specified branch %s: %w", ghc.Branch, err)
+	}
+	return *branch.Commit.SHA, nil
 }

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -81,22 +81,20 @@ func GetBranchPolicy(ctx context.Context, gh_connection *gh_control.GitHubConnec
 		return nil, "", err
 	}
 
-	if p == nil {
-		// No policy so return the default branch policy.
-		return &ProtectedBranch{
-			Name:                  gh_connection.Branch,
-			Since:                 time.Now(),
-			TargetSlsaSourceLevel: slsa_types.SlsaSourceLevel1,
-			RequireReview:         false}, "DEFAULT", nil
-	}
-
-	for _, pb := range p.ProtectedBranches {
-		if pb.Name == gh_connection.Branch {
-			return &pb, path, nil
+	if p != nil {
+		for _, pb := range p.ProtectedBranches {
+			if pb.Name == gh_connection.Branch {
+				return &pb, path, nil
+			}
 		}
 	}
 
-	return nil, "", fmt.Errorf("could not find rule for branch %s", gh_connection.Branch)
+	// No policy so return the default branch policy.
+	return &ProtectedBranch{
+		Name:                  gh_connection.Branch,
+		Since:                 time.Now(),
+		TargetSlsaSourceLevel: slsa_types.SlsaSourceLevel1,
+		RequireReview:         false}, "DEFAULT", nil
 }
 
 // Check to see if the local directory is a clean clone or not

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -169,6 +169,7 @@ func CreateLocalPolicy(ctx context.Context, gh_connection *gh_control.GitHubConn
 				Name:                  gh_connection.Branch,
 				Since:                 *eligibleSince,
 				TargetSlsaSourceLevel: eligibleLevel,
+				// TODO support filling in other controls too.
 			},
 		},
 	}

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -302,8 +302,18 @@ func evaluateControls(branchPolicy *ProtectedBranch, controls slsa_types.Control
 	return verifiedLevels, nil
 }
 
+type Policy struct {
+	// UNSAFE!
+	// Instead of grabbing the policy from the canonical repo, use the policy at this path instead.
+	UseLocalPolicy string
+}
+
+func NewPolicy() *Policy {
+	return &Policy{}
+}
+
 // Evaluates the control against the policy and returns the resulting source level and policy path.
-func EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnection, controlStatus *gh_control.GhControlStatus) (slsa_types.SourceVerifiedLevels, string, error) {
+func (policy Policy) EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnection, controlStatus *gh_control.GhControlStatus) (slsa_types.SourceVerifiedLevels, string, error) {
 	// We want to check to ensure the repo hasn't enabled/disabled the rules since
 	// setting the 'since' field in their policy.
 	branchPolicy, policyPath, err := GetBranchPolicy(ctx, gh_connection)
@@ -324,7 +334,7 @@ func EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnec
 }
 
 // Evaluates the provenance against the policy and returns the resulting source level and policy path
-func EvaluateProv(ctx context.Context, gh_connection *gh_control.GitHubConnection, prov *spb.Statement) (slsa_types.SourceVerifiedLevels, string, error) {
+func (policy Policy) EvaluateProv(ctx context.Context, gh_connection *gh_control.GitHubConnection, prov *spb.Statement) (slsa_types.SourceVerifiedLevels, string, error) {
 	branchPolicy, policyPath, err := GetBranchPolicy(ctx, gh_connection)
 	if err != nil {
 		return slsa_types.SourceVerifiedLevels{}, "", err

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -95,7 +95,7 @@ func (policy Policy) getPolicy(ctx context.Context, gh_connection *gh_control.Gi
 }
 
 // Gets the policy for the indicated branch direct from the GitHub repo.
-func (policy Policy) GetBranchPolicy(ctx context.Context, gh_connection *gh_control.GitHubConnection) (*ProtectedBranch, string, error) {
+func (policy Policy) getBranchPolicy(ctx context.Context, gh_connection *gh_control.GitHubConnection) (*ProtectedBranch, string, error) {
 	p, path, err := policy.getPolicy(ctx, gh_connection)
 
 	if err != nil {
@@ -337,7 +337,7 @@ func NewPolicy() *Policy {
 func (policy Policy) EvaluateControl(ctx context.Context, gh_connection *gh_control.GitHubConnection, controlStatus *gh_control.GhControlStatus) (slsa_types.SourceVerifiedLevels, string, error) {
 	// We want to check to ensure the repo hasn't enabled/disabled the rules since
 	// setting the 'since' field in their policy.
-	branchPolicy, policyPath, err := policy.GetBranchPolicy(ctx, gh_connection)
+	branchPolicy, policyPath, err := policy.getBranchPolicy(ctx, gh_connection)
 	if err != nil {
 		return slsa_types.SourceVerifiedLevels{}, "", err
 	}
@@ -356,7 +356,7 @@ func (policy Policy) EvaluateControl(ctx context.Context, gh_connection *gh_cont
 
 // Evaluates the provenance against the policy and returns the resulting source level and policy path
 func (policy Policy) EvaluateProv(ctx context.Context, gh_connection *gh_control.GitHubConnection, prov *spb.Statement) (slsa_types.SourceVerifiedLevels, string, error) {
-	branchPolicy, policyPath, err := policy.GetBranchPolicy(ctx, gh_connection)
+	branchPolicy, policyPath, err := policy.getBranchPolicy(ctx, gh_connection)
 	if err != nil {
 		return slsa_types.SourceVerifiedLevels{}, "", err
 	}

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -2,21 +2,22 @@ package slsa_types
 
 import "time"
 
-type SlsaSourceLevelData struct {
-	LevelName string
-	LevelNum  int
-}
-
-type SlsaSourceLevel *SlsaSourceLevelData
+type SlsaSourceLevel string
 
 const (
-	SlsaSourceLevel1    = "SLSA_SOURCE_LEVEL_1"
-	SlsaSourceLevel2    = "SLSA_SOURCE_LEVEL_2"
-	SlsaSourceLevel3    = "SLSA_SOURCE_LEVEL_3"
-	ContinuityEnforced  = "CONTINUITY_ENFORCED"
-	ProvenanceAvailable = "PROVENANCE_AVAILABLE"
-	ReviewEnforced      = "REVIEW_ENFORCED"
+	SlsaSourceLevel1    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
+	SlsaSourceLevel2    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
+	SlsaSourceLevel3    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
+	ContinuityEnforced                  = "CONTINUITY_ENFORCED"
+	ProvenanceAvailable                 = "PROVENANCE_AVAILABLE"
+	ReviewEnforced                      = "REVIEW_ENFORCED"
 )
+
+func IsLevelHigherOrEqualTo(level1, level2 SlsaSourceLevel) bool {
+	// There's probably some fancy stuff we can get in to, but...
+	// it just so happens that these level strings should sort the way we want.
+	return level1 >= level2
+}
 
 type Control struct {
 	// The name of the control
@@ -46,4 +47,19 @@ func (controls Controls) GetControl(name string) *Control {
 	return nil
 }
 
+// These can be any string, not just SlsaLevels
 type SourceVerifiedLevels []string
+
+func EarlierTime(time1, time2 time.Time) time.Time {
+	if time1.Before(time2) {
+		return time1
+	}
+	return time2
+}
+
+func LaterTime(time1, time2 time.Time) time.Time {
+	if time1.After(time2) {
+		return time1
+	}
+	return time2
+}


### PR DESCRIPTION

* Use a default L1 policy if the repo doesn't have its own policy defined.
* Use a default L1 policy if the _branch_ doesn't have its own policy defined.
* Policy creation now creates the highest level policy the repo is eligible for (but doesn't understand provenance :/).
* Support local (unsafe) policy eval to make development easier.