### PR TITLE
Get notes within the tool

### DIFF
--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -142,28 +142,21 @@ func (pa ProvenanceAttestor) convertLineToStatement(line string) (*spb.Statement
 	return nil, errors.New("could not convert line to statement")
 }
 
-func (pa ProvenanceAttestor) getPrevProvenance(ctx context.Context, prevAttPath, prevCommit string) (*spb.Statement, *SourceProvenancePred, error) {
-	var reader *bufio.Reader
-	if prevAttPath != "" {
-		f, err := os.Open(prevAttPath)
-		if err != nil {
-			return nil, nil, err
-		}
-		reader = bufio.NewReader(f)
-	} else {
-		// Try to get the previous bundle ourselves...
-		notes, err := pa.gh_connection.GetNotesForCommit(ctx, prevCommit)
-		if notes == "" {
-			log.Printf("didn't find prev commit %s for branch %s", prevCommit, pa.gh_connection.Branch)
-			return nil, nil, nil
-		}
-
-		if err != nil {
-			log.Fatal(err)
-		}
-		reader = bufio.NewReader(strings.NewReader(notes))
+// Gets provenance for the commit from git notes.
+func (pa ProvenanceAttestor) GetProvenance(ctx context.Context, commit string) (*spb.Statement, *SourceProvenancePred, error) {
+	notes, err := pa.gh_connection.GetNotesForCommit(ctx, commit)
+	if notes == "" {
+		log.Printf("didn't find prev commit %s for branch %s", commit, pa.gh_connection.Branch)
+		return nil, nil, nil
 	}
 
+	if err != nil {
+		log.Fatal(err)
+	}
+	return pa.getProvFromReader(bufio.NewReader(strings.NewReader(notes)), commit)
+}
+
+func (pa ProvenanceAttestor) getProvFromReader(reader *bufio.Reader, commit string) (*spb.Statement, *SourceProvenancePred, error) {
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
@@ -187,17 +180,30 @@ func (pa ProvenanceAttestor) getPrevProvenance(ctx context.Context, prevAttPath,
 			if err != nil {
 				return nil, nil, err
 			}
-			if doesSubjectIncludeCommit(sp, prevCommit) && prevProdPred.Branch == pa.gh_connection.GetFullBranch() {
+			if doesSubjectIncludeCommit(sp, commit) && prevProdPred.Branch == pa.gh_connection.GetFullBranch() {
 				// Should be good!
 				return sp, prevProdPred, nil
 			} else {
-				log.Printf("prev prov '%v' does not reference previous commit '%s' for branch '%s', skipping", sp, prevCommit, pa.gh_connection.GetFullBranch())
+				log.Printf("prov '%v' does not reference commit '%s' for branch '%s', skipping", sp, commit, pa.gh_connection.GetFullBranch())
 			}
 		}
 	}
 
-	log.Printf("didn't find prev commit %s for branch %s", prevCommit, pa.gh_connection.Branch)
+	log.Printf("didn't find commit %s for branch %s", commit, pa.gh_connection.Branch)
 	return nil, nil, nil
+}
+
+func (pa ProvenanceAttestor) getPrevProvenance(ctx context.Context, prevAttPath, prevCommit string) (*spb.Statement, *SourceProvenancePred, error) {
+	if prevAttPath != "" {
+		f, err := os.Open(prevAttPath)
+		if err != nil {
+			return nil, nil, err
+		}
+		return pa.getProvFromReader(bufio.NewReader(f), prevCommit)
+	}
+
+	// Try to get the previous bundle ourselves...
+	return pa.GetProvenance(ctx, prevCommit)
 }
 
 func (pa ProvenanceAttestor) CreateSourceProvenance(ctx context.Context, prevAttPath, commit, prevCommit string) (*spb.Statement, error) {
@@ -228,13 +234,15 @@ func (pa ProvenanceAttestor) CreateSourceProvenance(ctx context.Context, prevAtt
 
 	// There was prior provenance, so update the Since field for each property
 	// to the oldest encountered.
-	for _, curControl := range curProvPred.Controls {
+	for i, curControl := range curProvPred.Controls {
 		prevControl := prevProvPred.Controls.GetControl(curControl.Name)
 		// No prior version of this control
 		if prevControl == nil {
 			continue
 		}
 		curControl.Since = slsa_types.EarlierTime(curControl.Since, prevControl.Since)
+		// Update the value.
+		curProvPred.Controls[i] = curControl
 	}
 
 	return addPredToStatement(curProvPred, commit)

--- a/sourcetool/pkg/gh_control/notes.go
+++ b/sourcetool/pkg/gh_control/notes.go
@@ -1,0 +1,27 @@
+package gh_control
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/v69/github"
+)
+
+func (ghc *GitHubConnection) GetNotesForCommit(ctx context.Context, commit string) (string, error) {
+	// We can find the notes for a given commit fairly easily.
+	// They'll be in the path <commit> within ref `refs/notes/commits`
+
+	contents, _, resp, err := ghc.Client.Repositories.GetContents(
+		ctx, ghc.Owner, ghc.Repo, commit, &github.RepositoryContentGetOptions{Ref: "refs/notes/commits"})
+
+	if resp.StatusCode == http.StatusNotFound {
+		// Don't freak out if it's not there.
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("cannot get note contents for commit %s: %w", commit, err)
+	}
+
+	return contents.GetContent()
+}

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -173,12 +173,15 @@ func CreateLocalPolicy(ctx context.Context, gh_connection *gh_control.GitHubConn
 		return "", fmt.Errorf("could not get latest commit: %w", err)
 	}
 
-	controls, err := gh_connection.GetControls(ctx, latestCommit)
+	ver_options := attest.DefaultVerifierOptions
+	pa := attest.NewProvenanceAttestor(gh_connection, ver_options)
+	_, provPred, err := pa.GetProvenance(ctx, latestCommit)
 	if err != nil {
-		return "", fmt.Errorf("could not get controls: %w", err)
+		return "", fmt.Errorf("could not get provenance for latest commit: %w", err)
 	}
-	eligibleLevel, _ := computeEligibleSlsaLevel(controls.Controls)
-	eligibleSince, err := computeEligibleSince(controls.Controls, eligibleLevel)
+
+	eligibleLevel, _ := computeEligibleSlsaLevel(provPred.Controls)
+	eligibleSince, err := computeEligibleSince(provPred.Controls, eligibleLevel)
 	if err != nil {
 		return "", fmt.Errorf("could not compute eligible since: %w", err)
 	}


### PR DESCRIPTION
Added ability to get the notes from within the tool.

This will allow us to simplify the workflow and user experience.

Especially nice is that it allows the createpolicy command to get the provenance for the user.