### PR TITLE
have ruleset require linear history and squash commits

### DIFF
--- a/rulesets/source_level_3_basic.json
+++ b/rulesets/source_level_3_basic.json
@@ -1,25 +1,41 @@
 {
-    "id": 3410552,
-    "name": "SLSA Level 3 Basic",
-    "target": "branch",
-    "source_type": "Repository",
-    "source": "slsa-framework/slsa-source-poc",
-    "enforcement": "active",
-    "conditions": {
-      "ref_name": {
-        "exclude": [],
-        "include": [
-          "~DEFAULT_BRANCH"
+  "id": 3410552,
+  "name": "SLSA Controls",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "slsa-framework/slsa-source-poc",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash"
         ]
       }
-    },
-    "rules": [
-      {
-        "type": "deletion"
-      },
-      {
-        "type": "non_fast_forward"
-      }
-    ],
-    "bypass_actors": []
-  }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
refs #93

Adding linear history and squash commit requirement to the suggested ruleset.

Not actually enforced in the tool itself.