### PR TITLE
Add command to verify a commit

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,7 +19,7 @@ First, enable continuity controls within the target GitHub repo.
 Now, enable a workflow that will evaluate the SLSA level, create provenance, etc...
 
 1. Create a clean checkout of the target repo
-2. Create a new file named `./github/workflows/compute_slsa_source.yml`
+2. Create a new file named `.github/workflows/compute_slsa_source.yml`
 3. Add the following content
 
 ```yaml
@@ -44,11 +44,15 @@ jobs:
 
 Let's verify that everything is working
 
-1. Go to the GitHub repo
-2. Click the 'Actions' option
-3. Find the most recent run of `SLSA Source` (it should have a green check mark)
-4. Click into it
-5. You should see the summary listing "SLSA Source Properties": `[SLSA_SOURCE_LEVEL_1]`
+1. Note the digest of **merged** commit that added the workflow above
+2. Run the verification command
+
+`go run github.com/slsa-framework/slsa-source-poc/sourcetool@latest verifycommit --commit <commit digest> --owner <YOUR REPO'S ORG> --repo <YOUR REPO'S NAME> --branch main`
+
+3. You should see the message
+`SUCCESS: commit <commit digest> verified with [SLSA_SOURCE_LEVEL_1]`
+
+Move to the next section to get to `SLSA_SOURCE_LEVEL_3`.
 
 ## Create a policy file
 
@@ -73,3 +77,16 @@ e.g. `"canonical_repo": "https://github.com/TomHennen/wrangle",`
 5. Add & commit the created policy file.
 6. Send a PR with the change to https://github.com/slsa-framework/slsa-source-poc
 7. Once it's approved you'll be at SLSA Source Level 3 for your next change.
+
+## Validate Source Level 3 workflow
+
+Let's verify that everything is working
+
+1. Make and merge a change to the protected branch (`main`) in **your** repo.
+2. Note the digest of **merged** commit
+3. Run the verification command
+
+`go run github.com/slsa-framework/slsa-source-poc/sourcetool@latest verifycommit --commit <commit digest> --owner <YOUR REPO'S ORG> --repo <YOUR REPO'S NAME> --branch main`
+
+4. You should see the message
+`SUCCESS: commit <commit digest> verified with [SLSA_SOURCE_LEVEL_3]`

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -49,14 +49,6 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 		gh_control.NewGhConnection(checkLevelProvArgs.owner, checkLevelProvArgs.repo, checkLevelProvArgs.branch).WithAuthToken(githubToken)
 	ctx := context.Background()
 
-	ver_options := attest.DefaultVerifierOptions
-	if checkLevelProvArgs.expectedIssuer != "" {
-		ver_options.ExpectedIssuer = checkLevelProvArgs.expectedIssuer
-	}
-	if checkLevelProvArgs.expectedSan != "" {
-		ver_options.ExpectedSan = checkLevelProvArgs.expectedSan
-	}
-
 	prevCommit := checkLevelProvArgs.prevCommit
 	var err error
 	if prevCommit == "" {
@@ -66,7 +58,7 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 		}
 	}
 
-	pa := attest.NewProvenanceAttestor(gh_connection, ver_options)
+	pa := attest.NewProvenanceAttestor(gh_connection, getVerificationOptions())
 	prov, err := pa.CreateSourceProvenance(ctx, checkLevelProvArgs.prevBundlePath, checkLevelProvArgs.commit, prevCommit)
 	if err != nil {
 		log.Fatal(err)
@@ -142,8 +134,6 @@ func init() {
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.branch, "branch", "", "The branch within the repository - required.")
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.outputUnsignedBundle, "output_unsigned_bundle", "", "The path to write a bundle of unsigned attestations.")
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.outputSignedBundle, "output_signed_bundle", "", "The path to write a bundle of signed attestations.")
-	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.expectedIssuer, "expected_issuer", "", "The expected issuer of attestations.")
-	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.expectedSan, "expected_san", "", "The expect san of attestations.")
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
 
 }

--- a/sourcetool/cmd/root.go
+++ b/sourcetool/cmd/root.go
@@ -6,11 +6,14 @@ package cmd
 import (
 	"os"
 
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/spf13/cobra"
 )
 
 var (
-	githubToken string
+	githubToken    string
+	expectedIssuer string
+	expectedSan    string
 
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
@@ -28,6 +31,17 @@ to quickly create a Cobra application.`,
 	}
 )
 
+func getVerificationOptions() attest.VerificationOptions {
+	options := attest.DefaultVerifierOptions
+	if checkLevelProvArgs.expectedIssuer != "" {
+		options.ExpectedIssuer = checkLevelProvArgs.expectedIssuer
+	}
+	if checkLevelProvArgs.expectedSan != "" {
+		options.ExpectedSan = checkLevelProvArgs.expectedSan
+	}
+	return options
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -42,11 +56,8 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.sourcetool.yaml)")
-
 	rootCmd.PersistentFlags().StringVar(&githubToken, "github_token", "", "the github token to use for auth")
+	rootCmd.PersistentFlags().StringVar(&expectedIssuer, "expected_issuer", "", "The expected issuer of attestations.")
+	rootCmd.PersistentFlags().StringVar(&expectedSan, "expected_san", "", "The expect san of attestations.")
 
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -37,8 +37,7 @@ func doVerifyCommit(commit, owner, repo, branch string) {
 	gh_connection := gh_control.NewGhConnection(owner, repo, branch).WithAuthToken(githubToken)
 	ctx := context.Background()
 
-	// TODO: support overriding default verification options
-	pa := attest.NewProvenanceAttestor(gh_connection, attest.DefaultVerifierOptions)
+	pa := attest.NewProvenanceAttestor(gh_connection, getVerificationOptions())
 
 	_, vsaPred, err := pa.GetVsa(ctx, commit)
 	if err != nil {

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -44,7 +44,7 @@ func doVerifyCommit(commit, owner, repo, branch string) {
 		log.Fatal(err)
 	}
 	if vsaPred == nil {
-		fmt.Printf("FAILED: could not verify commit %s, no VSA found\n", commit)
+		fmt.Printf("FAILED: no VSA matching commit '%s' on branch '%s' found in github.com/%s/%s\n", commit, branch, owner, repo)
 		return
 	}
 

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+type VerifyCommitArgs struct {
+	owner, repo, branch, commit string
+}
+
+// checklevelCmd represents the checklevel command
+var (
+	verifyCommitArgs VerifyCommitArgs
+	verifycommitCmd  = &cobra.Command{
+		Use:   "verifycommit",
+		Short: "Verifies the specified commit is valid",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("verifycommit called")
+		},
+	}
+)
+
+func doVerifyCommit(commit, owner, repo, branch string) {
+	if commit == "" || owner == "" || repo == "" || branch == "" {
+		log.Fatal("Must set commit, owner, repo, and branch flags.")
+	}
+
+	gh_connection := gh_control.NewGhConnection(owner, repo, branch).WithAuthToken(githubToken)
+	ctx := context.Background()
+}
+
+func init() {
+	rootCmd.AddCommand(verifycommitCmd)
+
+	verifycommitCmd.Flags().StringVar(&verifyCommitArgs.owner, "owner", "", "The GitHub repository owner - required.")
+	verifycommitCmd.Flags().StringVar(&verifyCommitArgs.repo, "repo", "", "The GitHub repository name - required.")
+	verifycommitCmd.Flags().StringVar(&verifyCommitArgs.branch, "branch", "", "The branch within the repository - required.")
+	verifycommitCmd.Flags().StringVar(&verifyCommitArgs.commit, "commit", "", "The commit to check - required.")
+
+}

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -133,7 +133,7 @@ func (pa ProvenanceAttestor) GetProvenance(ctx context.Context, commit string) (
 
 func (pa ProvenanceAttestor) getProvFromReader(reader *BundleReader, commit string) (*spb.Statement, *SourceProvenancePred, error) {
 	for {
-		stmt, err := reader.ReadStatement(SourceProvPredicateType, commit)
+		stmt, err := reader.ReadStatement(MatchesTypeAndCommit(SourceProvPredicateType, commit))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	spb "github.com/in-toto/attestation/go/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -119,7 +118,7 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 func (pa ProvenanceAttestor) GetProvenance(ctx context.Context, commit string) (*spb.Statement, *SourceProvenancePred, error) {
 	notes, err := pa.gh_connection.GetNotesForCommit(ctx, commit)
 	if notes == "" {
-		log.Printf("didn't notes for commit %s", commit)
+		log.Printf("didn't find notes for commit %s", commit)
 		return nil, nil, nil
 	}
 

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -4,14 +4,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"strings"
 	"time"
 
+	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	spb "github.com/in-toto/attestation/go/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -92,15 +91,6 @@ func addPredToStatement(provPred *SourceProvenancePred, commit string) (*spb.Sta
 	return &statementPb, nil
 }
 
-func doesSubjectIncludeCommit(statement *spb.Statement, commit string) bool {
-	for _, subject := range statement.Subject {
-		if subject.Digest["gitCommit"] == commit {
-			return true
-		}
-	}
-	return false
-}
-
 // Create provenance for the current commit without any context from the previous provenance (if any).
 func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit, prevCommit string) (*spb.Statement, error) {
 	controlStatus, err := pa.gh_connection.GetControls(ctx, commit)
@@ -125,67 +115,49 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 	return addPredToStatement(&curProvPred, commit)
 }
 
-func (pa ProvenanceAttestor) convertLineToStatement(line string) (*spb.Statement, error) {
-	// Is this a sigstore bundle with a statement?
-	vr, err := Verify(line, pa.verification_options)
-	if err == nil {
-		// This is it.
-		return vr.Statement, nil
-	} else {
-		// We ignore errors because there could be other stuff in the
-		// bundle this line came from.
-		log.Printf("Line %s failed verification: %v", line, err)
-	}
-
-	// TODO: add support for 'regular' DSSEs.
-
-	return nil, errors.New("could not convert line to statement")
-}
-
 // Gets provenance for the commit from git notes.
 func (pa ProvenanceAttestor) GetProvenance(ctx context.Context, commit string) (*spb.Statement, *SourceProvenancePred, error) {
 	notes, err := pa.gh_connection.GetNotesForCommit(ctx, commit)
 	if notes == "" {
-		log.Printf("didn't find prev commit %s for branch %s", commit, pa.gh_connection.Branch)
+		log.Printf("didn't notes for commit %s", commit)
 		return nil, nil, nil
 	}
 
 	if err != nil {
 		log.Fatal(err)
 	}
-	return pa.getProvFromReader(bufio.NewReader(strings.NewReader(notes)), commit)
+
+	bundleReader := NewBundleReader(bufio.NewReader(strings.NewReader(notes)), pa.verification_options)
+
+	return pa.getProvFromReader(bundleReader, commit)
 }
 
-func (pa ProvenanceAttestor) getProvFromReader(reader *bufio.Reader, commit string) (*spb.Statement, *SourceProvenancePred, error) {
+func (pa ProvenanceAttestor) getProvFromReader(reader *BundleReader, commit string) (*spb.Statement, *SourceProvenancePred, error) {
 	for {
-		line, err := reader.ReadString('\n')
+		stmt, err := reader.ReadStatement(SourceProvPredicateType, commit)
 		if err != nil {
-			// Handle end of file gracefully
-			if err != io.EOF {
-				return nil, nil, err
-			}
-			if line == "" {
-				// Nothing to see here.
-				break
-			}
+			return nil, nil, err
 		}
-		// Is this source provenance?
-		sp, err := pa.convertLineToStatement(line)
-		if err == nil {
-			if sp.PredicateType != SourceProvPredicateType {
-				log.Printf("statement %v isn't source provenance", sp)
-				continue
-			}
-			prevProdPred, err := GetProvPred(sp)
-			if err != nil {
-				return nil, nil, err
-			}
-			if doesSubjectIncludeCommit(sp, commit) && prevProdPred.Branch == pa.gh_connection.GetFullBranch() {
-				// Should be good!
-				return sp, prevProdPred, nil
-			} else {
-				log.Printf("prov '%v' does not reference commit '%s' for branch '%s', skipping", sp, commit, pa.gh_connection.GetFullBranch())
-			}
+		if err != nil {
+			// Ignore errors, we want to check all the lines.
+			log.Printf("error while processing line: %v", err)
+			continue
+		}
+
+		if stmt == nil {
+			// No statements left.
+			break
+		}
+
+		prevProdPred, err := GetProvPred(stmt)
+		if err != nil {
+			return nil, nil, err
+		}
+		if prevProdPred.Branch == pa.gh_connection.GetFullBranch() {
+			// Should be good!
+			return stmt, prevProdPred, nil
+		} else {
+			log.Printf("prov '%v' does not reference commit '%s' for branch '%s', skipping", stmt, commit, pa.gh_connection.GetFullBranch())
 		}
 	}
 
@@ -199,7 +171,7 @@ func (pa ProvenanceAttestor) getPrevProvenance(ctx context.Context, prevAttPath,
 		if err != nil {
 			return nil, nil, err
 		}
-		return pa.getProvFromReader(bufio.NewReader(f), prevCommit)
+		return pa.getProvFromReader(NewBundleReader(bufio.NewReader(f), pa.verification_options), prevCommit)
 	}
 
 	// Try to get the previous bundle ourselves...

--- a/sourcetool/pkg/attest/statement.go
+++ b/sourcetool/pkg/attest/statement.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	spb "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type BundleReader struct {
@@ -45,7 +46,7 @@ func MatchesTypeAndCommit(predicateType, commit string) StatementMatcher {
 			return false
 		}
 		if !DoesSubjectIncludeCommit(statement, commit) {
-			log.Printf("statement %v does not match commit %s", statement, commit)
+			log.Printf("statement \n%v\n does not match commit %s", StatementToString(statement), commit)
 			return false
 		}
 		return true
@@ -98,4 +99,24 @@ func GetSubjectForCommit(statement *spb.Statement, commit string) *spb.ResourceD
 		}
 	}
 	return nil
+}
+
+// Just make this easy for logging...
+func StatementToString(stmt *spb.Statement) string {
+	if stmt == nil {
+		return "<nil>"
+	}
+
+	options := protojson.MarshalOptions{
+		Multiline:     true,
+		Indent:        " ",
+		AllowPartial:  true,
+		UseProtoNames: false,
+	}
+
+	jsonBytes, err := options.Marshal(stmt)
+	if err != nil {
+		return fmt.Sprintf("%v", err)
+	}
+	return string(jsonBytes)
 }

--- a/sourcetool/pkg/attest/statement.go
+++ b/sourcetool/pkg/attest/statement.go
@@ -1,0 +1,86 @@
+package attest
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+
+	spb "github.com/in-toto/attestation/go/v1"
+)
+
+type BundleReader struct {
+	reader               *bufio.Reader
+	verification_options VerificationOptions
+}
+
+func NewBundleReader(reader *bufio.Reader, verification_options VerificationOptions) *BundleReader {
+	return &BundleReader{reader: reader, verification_options: verification_options}
+}
+
+func (br BundleReader) convertLineToStatement(line string) (*spb.Statement, error) {
+	// Is this a sigstore bundle with a statement?
+	vr, err := Verify(line, br.verification_options)
+	if err == nil {
+		// This is it.
+		return vr.Statement, nil
+	} else {
+		// We ignore errors because there could be other stuff in the
+		// bundle this line came from.
+		log.Printf("Line %s failed verification: %v", line, err)
+	}
+
+	// TODO: add support for 'regular' DSSEs.
+
+	return nil, errors.New("could not convert line to statement")
+}
+
+// Reads all the statements that:
+// 1. Have the specified predicate type.
+// 2. Have a subject that matches the specified git commit.
+func (br *BundleReader) ReadStatement(predicateType, commit string) (*spb.Statement, error) {
+	// Read until we get a statement or end of file.
+	for {
+		line, err := br.reader.ReadString('\n')
+		if err != nil {
+			// Handle end of file gracefully
+			if err != io.EOF {
+				return nil, err
+			}
+			if line == "" {
+				// Nothing to see here.
+				break
+			}
+		}
+		statement, err := br.convertLineToStatement(line)
+		if err != nil {
+			return nil, fmt.Errorf("problem converting line to statement line: '%s', error: %w", line, err)
+		}
+		if statement == nil {
+			// Not sure what this is, just continue
+			continue
+		}
+		if statement.PredicateType != predicateType {
+			log.Printf("statement predicate type (%s) doesn't match %s", statement.PredicateType, predicateType)
+			continue
+		}
+		if DoesSubjectIncludeCommit(statement, commit) {
+			// A match!
+			return statement, nil
+		} else {
+			log.Printf("statement %v does not match commit %s", statement, commit)
+		}
+		// If we loop again it's because that line didn't have a matching statement
+	}
+	return nil, nil
+}
+
+func DoesSubjectIncludeCommit(statement *spb.Statement, commit string) bool {
+	for _, subject := range statement.Subject {
+		if subject.Digest["gitCommit"] == commit {
+			return true
+		}
+	}
+	return false
+}

--- a/sourcetool/pkg/attest/statement.go
+++ b/sourcetool/pkg/attest/statement.go
@@ -77,10 +77,16 @@ func (br *BundleReader) ReadStatement(predicateType, commit string) (*spb.Statem
 }
 
 func DoesSubjectIncludeCommit(statement *spb.Statement, commit string) bool {
+	return GetSubjectForCommit(statement, commit) != nil
+}
+
+// Returns the _first_ subject that includes the commit.
+// TODO: add support for multiple subjects...
+func GetSubjectForCommit(statement *spb.Statement, commit string) *spb.ResourceDescriptor {
 	for _, subject := range statement.Subject {
 		if subject.Digest["gitCommit"] == commit {
-			return true
+			return subject
 		}
 	}
-	return false
+	return nil
 }

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -111,8 +111,10 @@ func MatchesTypeCommitAndBranch(predicateType, commit, branch string) StatementM
 			log.Printf("statement has no branches: %v", statement)
 			return false
 		}
-		if !slices.Contains(branches, branch) {
+		branches_str, _ := branches.([]string)
+		if !slices.Contains(branches_str, branch) {
 			log.Printf("source_branches (%v) does not contain %s", branches, branch)
+			return false
 		}
 		return true
 	}
@@ -120,10 +122,7 @@ func MatchesTypeCommitAndBranch(predicateType, commit, branch string) StatementM
 
 func (pa ProvenanceAttestor) getVsaFromReader(reader *BundleReader, commit string) (*spb.Statement, *vpb.VerificationSummary, error) {
 	for {
-		stmt, err := reader.ReadStatement(VsaPredicateType, commit)
-		if err != nil {
-			return nil, nil, err
-		}
+		stmt, err := reader.ReadStatement(MatchesTypeCommitAndBranch(VsaPredicateType, commit, pa.gh_connection.GetFullBranch()))
 		if err != nil {
 			// Ignore errors, we want to check all the lines.
 			log.Printf("error while processing line: %v", err)
@@ -140,10 +139,6 @@ func (pa ProvenanceAttestor) getVsaFromReader(reader *BundleReader, commit strin
 			return nil, nil, err
 		}
 
-		// TODO: check that it came from the correct branch...
-		// // Does this VSA come from the right branch?
-		// subject := GetSubjectForCommit(stmt, commit)
-		// if subject.Annotations.AsMap()
 		return stmt, vsaPred, nil
 	}
 

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -102,16 +102,17 @@ func MatchesTypeCommitAndBranch(predicateType, commit, targetBranch string) Stat
 		}
 		subject := GetSubjectForCommit(statement, commit)
 		if subject == nil {
-			log.Printf("statement %v does not match commit %s", statement, commit)
+			log.Printf("statement \n%v\n does not match commit %s", StatementToString(statement), commit)
 			return false
 		}
 		branches := subject.GetAnnotations().Fields["source_branches"].GetListValue()
 		for _, branch := range branches.Values {
 			if branch.GetStringValue() == targetBranch {
+				log.Printf("statement \n%v\n matches commit '%s' on branch '%s'", StatementToString(statement), commit, targetBranch)
 				return true
 			}
 		}
-		log.Printf("source_branches (%v) does not contain %s", branches, targetBranch)
+		log.Printf("source_branches (%v) in VSA does not contain %s", branches, targetBranch)
 		return false
 	}
 }


### PR DESCRIPTION
This command will verify the SLSA Source Level of a given commit by looking for a valid VSA associated with that commit in the target repo.

Updated GETTING_STARTED to use this command instead of checking the Actions.