### PR TITLE
Implement tag immutability check

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -229,6 +229,19 @@ This tool can also check to see if the GitHub repo/ref is configured to require
     * "Require review from Code Owners"
     * "Require approval of the most recent reviewable push"
 
+### IMMUTABLE_TAGS
+
+This tool can also check to see if the GitHub repo is configured to require
+immutable tags.  To do so it checks that the repo:
+
+1. Doesn't allow tag updates
+2. Doesn't allow tag deletions
+3. Doesn't allow tag fast-forwards
+
+Importing [rulesets/tag_immutability.json](rulesets/tag_immutability.json)
+to a repos rulesets will enable the repo controls. The `immutable_tags`
+field in the policy then needs to be enabled too.
+
 ## Open Issues
 
 ### Dealing with reliability

--- a/policy/github.com/TomHennen/Concordance/source-policy.json
+++ b/policy/github.com/TomHennen/Concordance/source-policy.json
@@ -3,9 +3,10 @@
   "protected_branches": [
     {
       "Name": "master",
-      "Since": "2025-03-18T20:20:20.25099739Z",
+      "Since": "2025-03-23T18:08:43.25099739Z",
       "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3",
-      "require_review": false
+      "require_review": false,
+      "immutable_tags": true
     }
   ]
 }

--- a/rulesets/tag_immutability.json
+++ b/rulesets/tag_immutability.json
@@ -1,0 +1,28 @@
+{
+  "id": 4317154,
+  "name": "SLSA Tag Controls",
+  "target": "tag",
+  "source_type": "Repository",
+  "source": "TomHennen/Concordance",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "update"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -307,12 +307,12 @@ func computeReviewEnforced(branchPolicy *ProtectedBranch, controls slsa_types.Co
 	return true, nil
 }
 
-func computeTagImmutabilityEnforced(branchPolicy *ProtectedBranch, controls slsa_types.Controls) (bool, error) {
+func computeImmutableTags(branchPolicy *ProtectedBranch, controls slsa_types.Controls) (bool, error) {
 	if !branchPolicy.ImmutableTags {
 		return false, nil
 	}
 
-	immutableTags := controls.GetControl(slsa_types.TagImmutabilityEnforced)
+	immutableTags := controls.GetControl(slsa_types.ImmutableTags)
 	if immutableTags == nil {
 		return false, fmt.Errorf("policy requires immutable tags, but that control is not enabled")
 	}
@@ -341,12 +341,12 @@ func evaluateControls(branchPolicy *ProtectedBranch, controls slsa_types.Control
 		verifiedLevels = append(verifiedLevels, slsa_types.ReviewEnforced)
 	}
 
-	tagImmutabilityEnforced, err := computeTagImmutabilityEnforced(branchPolicy, controls)
+	immutableTags, err := computeImmutableTags(branchPolicy, controls)
 	if err != nil {
 		return slsa_types.SourceVerifiedLevels{}, fmt.Errorf("error computing tag immutability enforced: %w", err)
 	}
-	if tagImmutabilityEnforced {
-		verifiedLevels = append(verifiedLevels, slsa_types.TagImmutabilityEnforced)
+	if immutableTags {
+		verifiedLevels = append(verifiedLevels, slsa_types.ImmutableTags)
 	}
 
 	return verifiedLevels, nil

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -5,12 +5,13 @@ import "time"
 type SlsaSourceLevel string
 
 const (
-	SlsaSourceLevel1    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
-	SlsaSourceLevel2    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
-	SlsaSourceLevel3    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
-	ContinuityEnforced                  = "CONTINUITY_ENFORCED"
-	ProvenanceAvailable                 = "PROVENANCE_AVAILABLE"
-	ReviewEnforced                      = "REVIEW_ENFORCED"
+	SlsaSourceLevel1        SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
+	SlsaSourceLevel2        SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
+	SlsaSourceLevel3        SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
+	ContinuityEnforced                      = "CONTINUITY_ENFORCED"
+	ProvenanceAvailable                     = "PROVENANCE_AVAILABLE"
+	ReviewEnforced                          = "REVIEW_ENFORCED"
+	TagImmutabilityEnforced                 = "TAG_IMMUTABILITY_ENFORCED"
 )
 
 func IsLevelHigherOrEqualTo(level1, level2 SlsaSourceLevel) bool {

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -5,13 +5,13 @@ import "time"
 type SlsaSourceLevel string
 
 const (
-	SlsaSourceLevel1        SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
-	SlsaSourceLevel2        SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
-	SlsaSourceLevel3        SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
-	ContinuityEnforced                      = "CONTINUITY_ENFORCED"
-	ProvenanceAvailable                     = "PROVENANCE_AVAILABLE"
-	ReviewEnforced                          = "REVIEW_ENFORCED"
-	TagImmutabilityEnforced                 = "TAG_IMMUTABILITY_ENFORCED"
+	SlsaSourceLevel1    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
+	SlsaSourceLevel2    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
+	SlsaSourceLevel3    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
+	ContinuityEnforced                  = "CONTINUITY_ENFORCED"
+	ProvenanceAvailable                 = "PROVENANCE_AVAILABLE"
+	ReviewEnforced                      = "REVIEW_ENFORCED"
+	ImmutableTags                       = "IMMUTABLE_TAGS"
 )
 
 func IsLevelHigherOrEqualTo(level1, level2 SlsaSourceLevel) bool {


### PR DESCRIPTION
This change adds the IMMUTABLE_TAGS check to provenance and the policy.

This is currently a _separate_ check from SLSA_SOURCE_LEVEL_3 but we could incorporate it if we wanted.

Still to do:

1. Update the reusable workflow and instructions to check tag pushes too.
2. Update the verify command to check tags.

refs #99