### PR TITLE
Start creation of a checktag command.

### DIFF
--- a/.github/workflows/local_attest.yml
+++ b/.github/workflows/local_attest.yml
@@ -2,6 +2,7 @@ name: SLSA Source
 on:
   push:
     branches: [ "main" ]
+    tags: ['**']
 
 jobs:
   # Whenever new source is pushed recompute the slsa source information.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -233,7 +233,8 @@ This tool can also check to see if the GitHub repo/ref is configured to require
 ### IMMUTABLE_TAGS
 
 This tool can also check to see if the GitHub repo is configured to require
-immutable tags.  To do so it checks that the repo:
+immutable tags.  To do so it checks that the repo enables the follow rules
+to ~ALL tags:
 
 1. Doesn't allow tag updates
 2. Doesn't allow tag deletions
@@ -242,6 +243,11 @@ immutable tags.  To do so it checks that the repo:
 Importing [rulesets/tag_immutability.json](rulesets/tag_immutability.json)
 to a repos rulesets will enable the repo controls. The `immutable_tags`
 field in the policy then needs to be enabled too.
+
+TODO: In the future this tool could be updated to allow some subset of tags
+to be updated (e.g. `latest`, `nightly`), but that feature is not yet
+supported. Tracked
+[here](https://github.com/slsa-framework/slsa-source-poc/issues/129).
 
 ## Open Issues
 

--- a/actions/slsa_with_provenance/action.yml
+++ b/actions/slsa_with_provenance/action.yml
@@ -22,10 +22,17 @@ runs:
     - id: setup
       run: mkdir -p metadata
       shell: bash
-    - id: determine_level
+    - id: handle_branch_push
+      if: ${{ startsWith(github.ref, 'refs/heads/') }}
       run: |
-        echo "## SLSA Source Properties" >> $GITHUB_STEP_SUMMARY
+        echo "## SLSA Source Properties Branch Push" >> $GITHUB_STEP_SUMMARY
         go run github.com/slsa-framework/slsa-source-poc/sourcetool@8de659f119d933d4cfaed300e7d8bd78528a48c7 --github_token ${{ github.token }} checklevelprov --commit ${{ github.sha }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --branch ${{ github.ref_name }} --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
+      shell: bash
+    - id: handle_tag_push
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: |
+        echo "## SLSA Source Properties Tag Push" >> $GITHUB_STEP_SUMMARY
+        echo "TODO"
       shell: bash
     - id: summary
       run: |

--- a/go.work.sum
+++ b/go.work.sum
@@ -73,6 +73,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bufbuild/protocompile v0.10.0/go.mod h1:G9qQIQo0xZ6Uyj6CMNz0saGmx2so+KONo8/KrELABiY=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/buildkite/agent/v3 v3.81.0/go.mod h1:edJeyycODRxaFvpT22rDGwaQ5oa4eB8GjtbjgX5VpFw=
 github.com/buildkite/go-pipeline v0.13.1/go.mod h1:2HHqlSFTYgHFhzedJu0LhLs9n5c9XkYnHiQFVN5HE4U=
 github.com/buildkite/interpolate v0.1.3/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
@@ -180,7 +181,6 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/wire v0.6.0/go.mod h1:F4QhpQ9EDIdJ1Mbop/NZBRB+5yrR6qg3BnctaoUk6NA=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/policy/github.com/TomHennen/Concordance/source-policy.json
+++ b/policy/github.com/TomHennen/Concordance/source-policy.json
@@ -5,8 +5,11 @@
       "Name": "master",
       "Since": "2025-03-23T18:08:43.25099739Z",
       "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3",
-      "require_review": false,
-      "immutable_tags": true
+      "require_review": false
     }
-  ]
+  ],
+  "protected_tag": {
+    "Since": "2025-03-23T18:08:43.25099739Z",
+    "immutable_tags": true
+  }
 }

--- a/sourcetool/cmd/checktag.go
+++ b/sourcetool/cmd/checktag.go
@@ -1,0 +1,108 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type CheckTagArgs struct {
+	commit             string
+	owner              string
+	repo               string
+	tagName            string
+	outputSignedBundle string
+	useLocalPolicy     string
+}
+
+var (
+	checkTagArgs CheckTagArgs
+	// checktagCmd represents the checktag command
+	checktagCmd = &cobra.Command{
+		Use:   "checktag",
+		Short: "Checks to see if the tag operation should be allowed and issues a VSA",
+		Run: func(cmd *cobra.Command, args []string) {
+			doCheckTag(checkTagArgs)
+		},
+	}
+)
+
+func doCheckTag(args CheckTagArgs) {
+	gh_connection :=
+		gh_control.NewGhConnection(args.owner, args.repo, gh_control.TagToFullRef(args.tagName)).WithAuthToken(githubToken)
+	ctx := context.Background()
+	verifier := getVerifier()
+
+	// Create tag provenance.
+	pa := attest.NewProvenanceAttestor(gh_connection, verifier)
+	prov, err := pa.CreateTagProvenance(ctx, args.commit, gh_control.TagToFullRef(args.tagName))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// check p against policy
+	pe := policy.NewPolicyEvaluator()
+	pe.UseLocalPolicy = args.useLocalPolicy
+	verifiedLevels, policyPath, err := pe.EvaluateTagProv(ctx, gh_connection, prov)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// create vsa
+	unsignedVsa, err := attest.CreateUnsignedSourceVsa(gh_connection.GetRepoUri(), gh_connection.GetFullRef(), args.commit, verifiedLevels, policyPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	unsignedProv, err := protojson.Marshal(prov)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if args.outputSignedBundle != "" {
+		f, err := os.OpenFile(args.outputSignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+
+		signedProv, err := attest.Sign(string(unsignedProv))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		signedVsa, err := attest.Sign(unsignedVsa)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		f.WriteString(signedProv)
+		f.WriteString("\n")
+		f.WriteString(signedVsa)
+		f.WriteString("\n")
+	} else {
+		log.Printf("unsigned prov: %s\n", unsignedProv)
+		log.Printf("unsigned vsa: %s\n", unsignedVsa)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(checktagCmd)
+
+	checktagCmd.Flags().StringVar(&checkTagArgs.commit, "commit", "", "The commit to check - required.")
+	checktagCmd.Flags().StringVar(&checkTagArgs.owner, "owner", "", "The GitHub repository owner - required.")
+	checktagCmd.Flags().StringVar(&checkTagArgs.repo, "repo", "", "The GitHub repository name - required.")
+	checktagCmd.Flags().StringVar(&checkTagArgs.tagName, "tag_name", "", "The name of the new tag - required.")
+	checktagCmd.Flags().StringVar(&checkTagArgs.outputSignedBundle, "output_signed_bundle", "", "The path to write a bundle of signed attestations.")
+	checktagCmd.Flags().StringVar(&checkTagArgs.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
+
+}

--- a/sourcetool/cmd/createpolicy.go
+++ b/sourcetool/cmd/createpolicy.go
@@ -35,7 +35,7 @@ var (
 )
 
 func doCreatePolicy(policyRepoPath, owner, repo, branch string) {
-	gh_connection := gh_control.NewGhConnection(owner, repo, branch).WithAuthToken(githubToken)
+	gh_connection := gh_control.NewGhConnection(owner, repo, gh_control.BranchToFullRef(branch)).WithAuthToken(githubToken)
 	ctx := context.Background()
 	outpath, err := policy.CreateLocalPolicy(ctx, gh_connection, policyRepoPath)
 	if err != nil {

--- a/sourcetool/cmd/prov.go
+++ b/sourcetool/cmd/prov.go
@@ -32,10 +32,10 @@ var (
 )
 
 func doProv(prevAttPath, commit, prevCommit, owner, repo, branch string) {
-	gh_connection := gh_control.NewGhConnection(owner, repo, branch).WithAuthToken(githubToken)
+	gh_connection := gh_control.NewGhConnection(owner, repo, gh_control.BranchToFullRef(branch)).WithAuthToken(githubToken)
 	ctx := context.Background()
-	pa := attest.NewProvenanceAttestor(gh_connection, attest.DefaultVerifierOptions)
-	newProv, err := pa.CreateSourceProvenance(ctx, prevAttPath, commit, prevCommit)
+	pa := attest.NewProvenanceAttestor(gh_connection, getVerifier())
+	newProv, err := pa.CreateSourceProvenance(ctx, prevAttPath, commit, prevCommit, gh_connection.GetFullRef())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/cmd/root.go
+++ b/sourcetool/cmd/root.go
@@ -31,7 +31,7 @@ to quickly create a Cobra application.`,
 	}
 )
 
-func getVerificationOptions() attest.VerificationOptions {
+func getVerifier() attest.Verifier {
 	options := attest.DefaultVerifierOptions
 	if checkLevelProvArgs.expectedIssuer != "" {
 		options.ExpectedIssuer = checkLevelProvArgs.expectedIssuer
@@ -39,7 +39,7 @@ func getVerificationOptions() attest.VerificationOptions {
 	if checkLevelProvArgs.expectedSan != "" {
 		options.ExpectedSan = checkLevelProvArgs.expectedSan
 	}
-	return options
+	return attest.NewBndVerifier(options)
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -34,12 +34,10 @@ func doVerifyCommit(commit, owner, repo, branch string) {
 		log.Fatal("Must set commit, owner, repo, and branch flags.")
 	}
 
-	gh_connection := gh_control.NewGhConnection(owner, repo, branch).WithAuthToken(githubToken)
+	gh_connection := gh_control.NewGhConnection(owner, repo, gh_control.BranchToFullRef(branch)).WithAuthToken(githubToken)
 	ctx := context.Background()
 
-	pa := attest.NewProvenanceAttestor(gh_connection, getVerificationOptions())
-
-	_, vsaPred, err := pa.GetVsa(ctx, commit)
+	_, vsaPred, err := attest.GetVsa(ctx, gh_connection, getVerifier(), commit, gh_connection.GetFullRef())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sourcetool/go.mod
+++ b/sourcetool/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/google/go-github/v69 v69.2.0
 	github.com/in-toto/attestation v1.1.1
+	github.com/migueleliasweb/go-github-mock v1.3.0
 	github.com/sigstore/sigstore-go v0.7.0
 	github.com/spf13/cobra v1.9.1
 	google.golang.org/protobuf v1.36.5
@@ -47,8 +48,10 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/certificate-transparency-go v1.3.1 // indirect
 	github.com/google/go-containerregistry v0.20.3 // indirect
+	github.com/google/go-github/v71 v71.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
@@ -109,6 +112,7 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241219192143-6b3ec007d9bb // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/sourcetool/go.sum
+++ b/sourcetool/go.sum
@@ -177,12 +177,14 @@ github.com/google/certificate-transparency-go v1.3.1 h1:akbcTfQg0iZlANZLn0L9xOeW
 github.com/google/certificate-transparency-go v1.3.1/go.mod h1:gg+UQlx6caKEDQ9EElFOujyxEQEfOiQzAt6782Bvi8k=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-containerregistry v0.20.3 h1:oNx7IdTI936V8CQRveCjaxOiegWwvM7kqkbXTpyiovI=
 github.com/google/go-containerregistry v0.20.3/go.mod h1:w00pIgBRDVUDFM6bq+Qx8lwNWK+cxgCuX1vd3PIBDNI=
 github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
 github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
+github.com/google/go-github/v71 v71.0.0 h1:Zi16OymGKZZMm8ZliffVVJ/Q9YZreDKONCr+WUd0Z30=
+github.com/google/go-github/v71 v71.0.0/go.mod h1:URZXObp2BLlMjwu0O8g4y6VBneUj2bCHgnI8FfgZ51M=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
@@ -199,6 +201,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gT
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
@@ -275,6 +279,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/migueleliasweb/go-github-mock v1.3.0 h1:2sVP9JEMB2ubQw1IKto3/fzF51oFC6eVWOOFDgQoq88=
+github.com/migueleliasweb/go-github-mock v1.3.0/go.mod h1:ipQhV8fTcj/G6m7BKzin08GaJ/3B5/SonRAkgrk0zCY=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -1,0 +1,181 @@
+package attest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v69/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/gh_control"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa_types"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/testsupport"
+)
+
+var rulesetOldTime = time.Now().Add(-time.Hour)
+
+func rulesForTagImmutability() *github.RepositoryRulesetRules {
+	return &github.RepositoryRulesetRules{
+		Update:         &github.UpdateRuleParameters{},
+		Deletion:       &github.EmptyRuleParameters{},
+		NonFastForward: &github.EmptyRuleParameters{},
+	}
+}
+
+func conditionsForTagImmutability() *github.RepositoryRulesetConditions {
+	return &github.RepositoryRulesetConditions{
+		RefName: &github.RepositoryRulesetRefConditionParameters{
+			Include: []string{"~ALL"},
+		},
+	}
+}
+
+func createTestVsa(t *testing.T, repoUri, ref, commit string, verifiedLevels slsa_types.SourceVerifiedLevels) string {
+	vsa, err := CreateUnsignedSourceVsa(repoUri, ref, commit, verifiedLevels, "test-policy")
+	if err != nil {
+		t.Fatalf("failure creating test vsa: %v", err)
+	}
+	return vsa
+}
+
+func newNotesContent(content string) *github.RepositoryContent {
+	return &github.RepositoryContent{
+		Content: github.Ptr(content),
+	}
+}
+
+func newImmutableTagsRulesetsResponse(id int64, target github.RulesetTarget, enforcement github.RulesetEnforcement,
+	updatedAt time.Time) *github.RepositoryRuleset {
+	return &github.RepositoryRuleset{
+		ID:          github.Ptr(id),
+		Target:      github.Ptr(target),
+		Enforcement: enforcement,
+		UpdatedAt:   github.Ptr(github.Timestamp{Time: updatedAt}),
+		Rules:       rulesForTagImmutability(),
+		Conditions:  conditionsForTagImmutability(),
+	}
+}
+
+func newMockedGitHubClient(rulesetResponse *github.RepositoryRuleset, notesContent *github.RepositoryContent) *github.Client {
+	return github.NewClient(mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposRulesetsByOwnerByRepo,
+			[]*github.RepositoryRuleset{
+				rulesetResponse,
+			},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposRulesetsByOwnerByRepoByRulesetId,
+			*rulesetResponse,
+		),
+		mock.WithRequestMatch(
+			mock.GetReposContentsByOwnerByRepoByPath,
+			*notesContent,
+		),
+	))
+}
+
+// Helper to create a test GH Branch connection with no client.
+func newTestGhConnection(owner, repo, branch string, rulesetResponse *github.RepositoryRuleset, notesContent *github.RepositoryContent) *gh_control.GitHubConnection {
+	return gh_control.NewGhConnectionWithClient(
+		owner, repo, gh_control.BranchToFullRef(branch),
+		newMockedGitHubClient(rulesetResponse, notesContent))
+}
+
+func timesEqualWithinMargin(t1, t2 time.Time, margin time.Duration) bool {
+	diff := t1.Sub(t2).Abs()
+	return diff <= margin
+}
+
+func assertTagProvPredsEqual(t *testing.T, actual, expected TagProvenancePred) {
+	if actual.ActivityType != expected.ActivityType {
+		t.Errorf("ActivityType %v does not match expected value %v", actual.ActivityType, expected.ActivityType)
+	}
+
+	if actual.Actor != expected.Actor {
+		t.Errorf("Actor %v does not match expected value %v", actual.Actor, expected.Actor)
+	}
+
+	if actual.RepoUri != expected.RepoUri {
+		t.Errorf("RepoUri %v does not match expected value %v", actual.RepoUri, expected.RepoUri)
+	}
+
+	if actual.Tag != expected.Tag {
+		t.Errorf("Tag %v does not match expected value %v", actual.Tag, expected.Tag)
+	}
+
+	if timesEqualWithinMargin(actual.CreatedOn, expected.CreatedOn, 5*time.Second) {
+		t.Errorf("CreatedOn %v does not match expected value %v", actual.CreatedOn, expected.CreatedOn)
+	}
+
+	if len(actual.Controls) != len(expected.Controls) {
+		t.Errorf("Control %v does not match expected value %v", actual.Controls, expected.Controls)
+	} else {
+		for ci, _ := range actual.Controls {
+			if !timesEqualWithinMargin(actual.Controls[ci].Since, expected.Controls[ci].Since, time.Second) {
+				t.Errorf("control at [%d]'s time %v does not match expected time %v", ci,
+					actual.Controls[ci].Since, expected.Controls[ci].Since)
+			}
+		}
+	}
+	if !reflect.DeepEqual(actual.VsaSummaries, expected.VsaSummaries) {
+		t.Errorf("VsaSummaries %v does not match expected value %v", actual.VsaSummaries, expected.VsaSummaries)
+	}
+}
+
+func TestCreateTagProvenance(t *testing.T) {
+	testVsa := createTestVsa(t, "http://repo", "refs/some/ref", "abc123", slsa_types.SourceVerifiedLevels{"TEST_LEVEL"})
+
+	ghc := newTestGhConnection("owner", "repo", "branch",
+		newImmutableTagsRulesetsResponse(123, github.RulesetTargetTag,
+			github.RulesetEnforcementActive, rulesetOldTime),
+		newNotesContent(testVsa))
+	verifier := testsupport.NewMockVerifier()
+
+	pa := NewProvenanceAttestor(ghc, verifier)
+
+	stmt, err := pa.CreateTagProvenance(context.Background(), "abc123", "refs/tags/v1")
+	if err != nil {
+		t.Fatalf("error creating tag prov %v", err)
+	}
+
+	if stmt == nil {
+		t.Fatalf("returned statement is nil")
+	}
+
+	if stmt.PredicateType != TagProvPredicateType {
+		t.Errorf("statement pred type %v does not match expected %v", stmt.PredicateType, TagProvPredicateType)
+	}
+
+	if !DoesSubjectIncludeCommit(stmt, "abc123") {
+		t.Errorf("statement subject %v does not match expected %v", stmt.Subject, "abc123")
+	}
+
+	tagPred, err := GetTagProvPred(stmt)
+	if err != nil {
+		t.Fatalf("error getting tag prov %v", err)
+	}
+
+	expectedPred := TagProvenancePred{
+		RepoUri:      "https://github.com/owner/repo",
+		Actor:        "unknown actor",
+		ActivityType: "unknown activity type",
+		Tag:          "refs/tags/v1",
+		CreatedOn:    rulesetOldTime,
+		Controls: []slsa_types.Control{
+			{
+				Name:  "IMMUTABLE_TAGS",
+				Since: rulesetOldTime,
+			},
+		},
+		VsaSummaries: []VsaSummary{
+			{
+				SourceRefs:     []string{"refs/some/ref"},
+				VerifiedLevels: []string{"TEST_LEVEL"},
+			},
+		},
+	}
+
+	assertTagProvPredsEqual(t, *tagPred, expectedPred)
+}

--- a/sourcetool/pkg/attest/statement.go
+++ b/sourcetool/pkg/attest/statement.go
@@ -12,17 +12,17 @@ import (
 )
 
 type BundleReader struct {
-	reader               *bufio.Reader
-	verification_options VerificationOptions
+	reader   *bufio.Reader
+	verifier Verifier
 }
 
-func NewBundleReader(reader *bufio.Reader, verification_options VerificationOptions) *BundleReader {
-	return &BundleReader{reader: reader, verification_options: verification_options}
+func NewBundleReader(reader *bufio.Reader, verifier Verifier) *BundleReader {
+	return &BundleReader{reader: reader, verifier: verifier}
 }
 
 func (br BundleReader) convertLineToStatement(line string) (*spb.Statement, error) {
 	// Is this a sigstore bundle with a statement?
-	vr, err := Verify(line, br.verification_options)
+	vr, err := br.verifier.Verify(line)
 	if err == nil {
 		// This is it.
 		return vr.Statement, nil

--- a/sourcetool/pkg/attest/verify.go
+++ b/sourcetool/pkg/attest/verify.go
@@ -17,15 +17,31 @@ var DefaultVerifierOptions = VerificationOptions{
 	ExpectedSan:    "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/heads/main",
 }
 
-func Verify(data string, options VerificationOptions) (*verify.VerificationResult, error) {
+type Verifier interface {
+	Verify(data string) (*verify.VerificationResult, error)
+}
+
+type BndVerifier struct {
+	Options VerificationOptions
+}
+
+func (bv *BndVerifier) Verify(data string) (*verify.VerificationResult, error) {
 	// TODO: There's more for us to do here... but what?
 	// Maybe check to make sure it's from the identity we expect (the workflow?)
 	verifier := bnd.NewVerifier()
-	verifier.Options.ExpectedIssuer = options.ExpectedIssuer
-	verifier.Options.ExpectedSan = options.ExpectedSan
+	verifier.Options.ExpectedIssuer = bv.Options.ExpectedIssuer
+	verifier.Options.ExpectedSan = bv.Options.ExpectedSan
 	vr, err := verifier.VerifyInlineBundle([]byte(data))
 	if err != nil {
 		return nil, err
 	}
 	return vr, nil
+}
+
+func NewBndVerifier(options VerificationOptions) *BndVerifier {
+	return &BndVerifier{Options: options}
+}
+
+func GetDefaultVerifier() Verifier {
+	return NewBndVerifier(DefaultVerifierOptions)
 }

--- a/sourcetool/pkg/gh_control/git_types.go
+++ b/sourcetool/pkg/gh_control/git_types.go
@@ -1,0 +1,26 @@
+package gh_control
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Matches any reference type.
+const AnyReference = "*"
+
+func BranchToFullRef(branch string) string {
+	return fmt.Sprintf("refs/heads/%s", branch)
+}
+
+func TagToFullRef(tag string) string {
+	return fmt.Sprintf("refs/tags/%s", tag)
+}
+
+// Returns "" if the ref isn't a branch
+func GetBranchFromRef(ref string) string {
+	return strings.TrimPrefix(ref, "refs/heads/")
+}
+
+func GetTagFromRef(ref string) string {
+	return strings.TrimPrefix(ref, "refs/tags/")
+}

--- a/sourcetool/pkg/gh_control/notes.go
+++ b/sourcetool/pkg/gh_control/notes.go
@@ -12,8 +12,8 @@ func (ghc *GitHubConnection) GetNotesForCommit(ctx context.Context, commit strin
 	// We can find the notes for a given commit fairly easily.
 	// They'll be in the path <commit> within ref `refs/notes/commits`
 
-	contents, _, resp, err := ghc.Client.Repositories.GetContents(
-		ctx, ghc.Owner, ghc.Repo, commit, &github.RepositoryContentGetOptions{Ref: "refs/notes/commits"})
+	contents, _, resp, err := ghc.Client().Repositories.GetContents(
+		ctx, ghc.Owner(), ghc.Repo(), commit, &github.RepositoryContentGetOptions{Ref: "refs/notes/commits"})
 
 	if resp.StatusCode == http.StatusNotFound {
 		// Don't freak out if it's not there.
@@ -21,6 +21,10 @@ func (ghc *GitHubConnection) GetNotesForCommit(ctx context.Context, commit strin
 	}
 	if err != nil {
 		return "", fmt.Errorf("cannot get note contents for commit %s: %w", commit, err)
+	}
+	if contents == nil {
+		// No notes stored for this commit.
+		return "", nil
 	}
 
 	return contents.GetContent()

--- a/sourcetool/pkg/testsupport/mockverify.go
+++ b/sourcetool/pkg/testsupport/mockverify.go
@@ -1,0 +1,29 @@
+package testsupport
+
+import (
+	"fmt"
+
+	spb "github.com/in-toto/attestation/go/v1"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type MockVerifier struct {
+}
+
+func NewMockVerifier() *MockVerifier {
+	return &MockVerifier{}
+}
+
+func (mv *MockVerifier) Verify(data string) (*verify.VerificationResult, error) {
+	var statement spb.Statement
+	err := protojson.Unmarshal([]byte(data), &statement)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling %s into statement", data)
+	}
+
+	var vr verify.VerificationResult
+	vr.MediaType = "mockverifiermediatype"
+	vr.Statement = &statement
+	return &vr, nil
+}


### PR DESCRIPTION
This command will eventually create tag provenance and VSAs. It's currently partially implemented.

Added an outline of a local flow that will eventually call this command.

This was a fairly large refactor that involved generalizing the GitHubConnection class so that it doesn't assume there are branches and being able to mock the bnd verifier to make unit tests possible/easier.