### PR TITLE
Use checktag

### DIFF
--- a/actions/slsa_with_provenance/action.yml
+++ b/actions/slsa_with_provenance/action.yml
@@ -32,6 +32,7 @@ runs:
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
         echo "## SLSA Source Properties Tag Push" >> $GITHUB_STEP_SUMMARY
+        echo "github object contents ${{ github }}"
         go run github.com/slsa-framework/slsa-source-poc/sourcetool@f2031f563fc7323ce160313a13d456e4422244c9 --github_token ${{ github.token }} checktag --commit ${{ github.sha }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --tag_name ${{ github.ref_name }} --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
     - id: summary

--- a/actions/slsa_with_provenance/action.yml
+++ b/actions/slsa_with_provenance/action.yml
@@ -26,13 +26,13 @@ runs:
       if: ${{ startsWith(github.ref, 'refs/heads/') }}
       run: |
         echo "## SLSA Source Properties Branch Push" >> $GITHUB_STEP_SUMMARY
-        go run github.com/slsa-framework/slsa-source-poc/sourcetool@8de659f119d933d4cfaed300e7d8bd78528a48c7 --github_token ${{ github.token }} checklevelprov --commit ${{ github.sha }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --branch ${{ github.ref_name }} --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
+        go run github.com/slsa-framework/slsa-source-poc/sourcetool@f2031f563fc7323ce160313a13d456e4422244c9 --github_token ${{ github.token }} checklevelprov --commit ${{ github.sha }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --branch ${{ github.ref_name }} --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
     - id: handle_tag_push
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
         echo "## SLSA Source Properties Tag Push" >> $GITHUB_STEP_SUMMARY
-        echo "TODO"
+        go run github.com/slsa-framework/slsa-source-poc/sourcetool@f2031f563fc7323ce160313a13d456e4422244c9 --github_token ${{ github.token }} checktag --commit ${{ github.sha }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --tag_name ${{ github.ref_name }} --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
     - id: summary
       run: |


### PR DESCRIPTION
Use checktag when tags are pushed.

Also updates the action to use the new version of the tool for branch updates and adds debugging to see what other data we have available.
