### PR TITLE
Store actor who created the tag in prov

### DIFF
--- a/actions/slsa_with_provenance/action.yml
+++ b/actions/slsa_with_provenance/action.yml
@@ -32,9 +32,6 @@ runs:
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
         echo "## SLSA Source Properties Tag Push" >> $GITHUB_STEP_SUMMARY
-        echo "github.actor ${{ github.actor }}"
-        echo "github.triggering_actor ${{ github.triggering_actor }}"
-        echo "github.event_name ${{ github.event_name }}"
         go run github.com/slsa-framework/slsa-source-poc/sourcetool@f2031f563fc7323ce160313a13d456e4422244c9 --github_token ${{ github.token }} checktag --commit ${{ github.sha }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --tag_name ${{ github.ref_name }} --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
     - id: summary

--- a/sourcetool/cmd/checktag.go
+++ b/sourcetool/cmd/checktag.go
@@ -20,6 +20,7 @@ type CheckTagArgs struct {
 	owner              string
 	repo               string
 	tagName            string
+	actor              string
 	outputSignedBundle string
 	useLocalPolicy     string
 }
@@ -44,7 +45,7 @@ func doCheckTag(args CheckTagArgs) {
 
 	// Create tag provenance.
 	pa := attest.NewProvenanceAttestor(gh_connection, verifier)
-	prov, err := pa.CreateTagProvenance(ctx, args.commit, gh_control.TagToFullRef(args.tagName))
+	prov, err := pa.CreateTagProvenance(ctx, args.commit, gh_control.TagToFullRef(args.tagName), args.actor)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -102,6 +103,7 @@ func init() {
 	checktagCmd.Flags().StringVar(&checkTagArgs.owner, "owner", "", "The GitHub repository owner - required.")
 	checktagCmd.Flags().StringVar(&checkTagArgs.repo, "repo", "", "The GitHub repository name - required.")
 	checktagCmd.Flags().StringVar(&checkTagArgs.tagName, "tag_name", "", "The name of the new tag - required.")
+	checktagCmd.Flags().StringVar(&checkTagArgs.actor, "actor", "", "The username of the actor that pushed the tag.")
 	checktagCmd.Flags().StringVar(&checkTagArgs.outputSignedBundle, "output_signed_bundle", "", "The path to write a bundle of signed attestations.")
 	checktagCmd.Flags().StringVar(&checkTagArgs.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
 

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -45,11 +45,10 @@ type VsaSummary struct {
 }
 
 type TagProvenancePred struct {
-	RepoUri      string    `json:"repo_uri"`
-	ActivityType string    `json:"activity_type"`
-	Actor        string    `json:"actor"`
-	Tag          string    `json:"tag"`
-	CreatedOn    time.Time `json:"created_on"`
+	RepoUri   string    `json:"repo_uri"`
+	Actor     string    `json:"actor"`
+	Tag       string    `json:"tag"`
+	CreatedOn time.Time `json:"created_on"`
 	// The tag related controls enabled at the time this tag was created/updated.
 	Controls     slsa_types.Controls `json:"controls"`
 	VsaSummaries []VsaSummary        `json:"vsa_summaries"`
@@ -274,7 +273,7 @@ func (pa ProvenanceAttestor) CreateSourceProvenance(ctx context.Context, prevAtt
 	return addPredToStatement(curProvPred, SourceProvPredicateType, commit)
 }
 
-func (pa ProvenanceAttestor) CreateTagProvenance(ctx context.Context, commit, ref string) (*spb.Statement, error) {
+func (pa ProvenanceAttestor) CreateTagProvenance(ctx context.Context, commit, ref, actor string) (*spb.Statement, error) {
 	// 1. Check that the immutable tags control is still enabled and how long it's been enabled, store it in the prov.
 	// 2. Get a VSA associated with this commit, if any.
 	// 3. Record the levels and branches covered by that VSA in the provenance.
@@ -304,12 +303,11 @@ func (pa ProvenanceAttestor) CreateTagProvenance(ctx context.Context, commit, re
 	}
 
 	curProvPred := TagProvenancePred{
-		RepoUri:      pa.gh_connection.GetRepoUri(),
-		Actor:        controlStatus.ActorLogin,
-		ActivityType: controlStatus.ActivityType,
-		Tag:          ref,
-		CreatedOn:    curTime,
-		Controls:     controlStatus.Controls,
+		RepoUri:   pa.gh_connection.GetRepoUri(),
+		Actor:     actor,
+		Tag:       ref,
+		CreatedOn: curTime,
+		Controls:  controlStatus.Controls,
 		VsaSummaries: []VsaSummary{
 			{
 				SourceRefs:     vsaRefs,

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -89,10 +89,6 @@ func timesEqualWithinMargin(t1, t2 time.Time, margin time.Duration) bool {
 }
 
 func assertTagProvPredsEqual(t *testing.T, actual, expected TagProvenancePred) {
-	if actual.ActivityType != expected.ActivityType {
-		t.Errorf("ActivityType %v does not match expected value %v", actual.ActivityType, expected.ActivityType)
-	}
-
 	if actual.Actor != expected.Actor {
 		t.Errorf("Actor %v does not match expected value %v", actual.Actor, expected.Actor)
 	}
@@ -135,7 +131,7 @@ func TestCreateTagProvenance(t *testing.T) {
 
 	pa := NewProvenanceAttestor(ghc, verifier)
 
-	stmt, err := pa.CreateTagProvenance(context.Background(), "abc123", "refs/tags/v1")
+	stmt, err := pa.CreateTagProvenance(context.Background(), "abc123", "refs/tags/v1", "the-tag-pusher")
 	if err != nil {
 		t.Fatalf("error creating tag prov %v", err)
 	}
@@ -158,11 +154,10 @@ func TestCreateTagProvenance(t *testing.T) {
 	}
 
 	expectedPred := TagProvenancePred{
-		RepoUri:      "https://github.com/owner/repo",
-		Actor:        "unknown actor",
-		ActivityType: "unknown activity type",
-		Tag:          "refs/tags/v1",
-		CreatedOn:    rulesetOldTime,
+		RepoUri:   "https://github.com/owner/repo",
+		Actor:     "the-tag-pusher",
+		Tag:       "refs/tags/v1",
+		CreatedOn: rulesetOldTime,
 		Controls: []slsa_types.Control{
 			{
 				Name:  "IMMUTABLE_TAGS",

--- a/sourcetool/pkg/gh_control/checklevel.go
+++ b/sourcetool/pkg/gh_control/checklevel.go
@@ -247,8 +247,6 @@ func (ghc *GitHubConnection) GetBranchControls(ctx context.Context, commit, ref 
 func (ghc *GitHubConnection) GetTagControls(ctx context.Context, commit, ref string) (*GhControlStatus, error) {
 	controlStatus := GhControlStatus{
 		CommitPushTime: time.Now(),
-		ActivityType:   "unknown activity type",
-		ActorLogin:     "unknown actor",
 		Controls:       slsa_types.Controls{}}
 
 	allRulesets, _, err := ghc.Client().Repositories.GetAllRulesets(ctx, ghc.Owner(), ghc.Repo(), true)


### PR DESCRIPTION
We can get it from the command line. Not as nice as the GH API, but it will do.  We can trust this data in production because it's coming from our reusable workflow which is used to sign the provenance.

Also removed 'ActivityType' since it's always going to be the same thing for tags.