### PR TITLE
Use source_refs instead of source_branches.

### DIFF
--- a/sourcetool/pkg/attest/statement_test.go
+++ b/sourcetool/pkg/attest/statement_test.go
@@ -1,0 +1,105 @@
+package attest
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	spb "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func newStatement(commit string, annotation *map[string]any) (*spb.Statement, error) {
+	var sub []*spb.ResourceDescriptor
+	if annotation != nil {
+		annotationStruct, err := structpb.NewStruct(*annotation)
+		if err != nil {
+			return nil, fmt.Errorf("creating struct from map: %w", err)
+		}
+		sub = []*spb.ResourceDescriptor{{
+			Digest:      map[string]string{"gitCommit": commit},
+			Annotations: annotationStruct,
+		}}
+	}
+
+	statementPb := spb.Statement{
+		Type:          spb.StatementTypeUri,
+		Subject:       sub,
+		PredicateType: "test",
+		Predicate:     &structpb.Struct{},
+	}
+	return &statementPb, nil
+}
+
+func stringToAnyArray(valArray []string) []any {
+	aa := make([]any, len(valArray))
+	for i, _ := range valArray {
+		aa[i] = valArray[i]
+	}
+	return aa
+}
+
+func TestGetSourceRefsForCommit(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotationName string
+		stmt           *spb.Statement
+		refs           []string
+		expectedRefs   []string
+		expectErr      bool
+	}{
+		{
+			name:           "source_refs with list",
+			annotationName: "source_refs",
+			refs:           []string{"foo"},
+			expectedRefs:   []string{"foo"},
+			expectErr:      false,
+		},
+		{
+			name:           "source_branches with list",
+			annotationName: "source_branches",
+			refs:           []string{"foo"},
+			expectedRefs:   []string{"foo"},
+			expectErr:      false,
+		},
+		{
+			name:           "empty refs",
+			annotationName: "source_refs",
+			refs:           []string{},
+			expectedRefs:   []string{},
+			expectErr:      false,
+		},
+		{
+			name:           "many refs",
+			annotationName: "source_refs",
+			refs:           []string{"foo", "bar", "baz"},
+			expectedRefs:   []string{"foo", "bar", "baz"},
+			expectErr:      false,
+		},
+		{
+			name:           "unknown annotation",
+			annotationName: "foo_refs",
+			refs:           []string{"foo", "bar", "baz"},
+			expectedRefs:   []string{},
+			expectErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt, err := newStatement("abc123", &map[string]any{tt.annotationName: stringToAnyArray(tt.refs)})
+			if err != nil {
+				t.Fatalf("error creating statement: %v", err)
+			}
+
+			gotRefs, err := GetSourceRefsForCommit(stmt, "abc123")
+
+			if err != nil && !tt.expectErr {
+				t.Errorf("did not expect error, got %v", err)
+			}
+
+			if !slices.Equal(gotRefs, tt.expectedRefs) {
+				t.Errorf("expected %v, got %v", tt.expectedRefs, gotRefs)
+			}
+		})
+	}
+}

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -35,7 +35,6 @@ func CreateUnsignedSourceVsa(repoUri, ref, commit string, verifiedLevels slsa_ty
 		return "", err
 	}
 
-	// TODO: update to source_refs to match updated spec.
 	branchAnnotation := map[string]any{slsa_types.SourceRefsAnnotation: []any{ref}}
 	annotationStruct, err := structpb.NewStruct(branchAnnotation)
 	if err != nil {
@@ -78,30 +77,6 @@ func GetVsa(ctx context.Context, ghc *gh_control.GitHubConnection, verifier Veri
 		log.Fatal(err)
 	}
 	return getVsaFromReader(NewBundleReader(bufio.NewReader(strings.NewReader(notes)), verifier), commit, ref)
-}
-
-func GetSourceRefsForCommit(vsaStatement *spb.Statement, commit string) ([]string, error) {
-	subject := GetSubjectForCommit(vsaStatement, commit)
-	if subject == nil {
-		return []string{}, fmt.Errorf("statement \n%v\n does not match commit %s", StatementToString(vsaStatement), commit)
-	}
-	annotations := subject.GetAnnotations()
-	sourceRefs, ok := annotations.Fields[slsa_types.SourceRefsAnnotation]
-	if !ok {
-		// This used to be called 'source_branches', maybe this is an old VSA.
-		// TODO: remove once we're not worried about backward compatibility.
-		sourceRefs, ok = annotations.Fields[slsa_types.SourceBranchesAnnotation]
-		if !ok {
-			return []string{}, fmt.Errorf("no source_refs or source_branches annotation in VSA subject")
-		}
-	}
-
-	protoRefs := sourceRefs.GetListValue()
-	stringRefs := []string{}
-	for _, ref := range protoRefs.Values {
-		stringRefs = append(stringRefs, ref.GetStringValue())
-	}
-	return stringRefs, nil
 }
 
 func getVsaPred(statement *spb.Statement) (*vpb.VerificationSummary, error) {

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -151,7 +151,6 @@ func checkLocalDir(ctx context.Context, gh_connection *gh_control.GitHubConnecti
 	}
 
 	// Is there a remote policy?
-	// TODO: Look for errors that _aren't_ 404.
 	rp, _, _ := getRemotePolicy(ctx, gh_connection)
 	if rp != nil {
 		return fmt.Errorf("policy already exists remotely for %s", getPolicyPath(gh_connection))
@@ -375,13 +374,13 @@ func evaluateTagProv(tagPolicy *ProtectedTag, tagProvPred *attest.TagProvenanceP
 	// As long as all the controls for tag protection are currently in force then we'll
 	// include the verifiedLevels.
 
-	// TODO: handle tag policy?
 	tagHygiene, err := computeTagHygiene(tagPolicy, tagProvPred.Controls)
 	if err != nil {
 		return slsa_types.SourceVerifiedLevels{}, fmt.Errorf("error computing tag immutability enforced: %w", err)
 	}
 	if tagHygiene {
 		// TODO: should we include the tag hygiene field specifically?
+		// TODO: Should we include the union of all the levels (probably).
 		return tagProvPred.VsaSummaries[0].VerifiedLevels, nil
 	}
 
@@ -467,7 +466,6 @@ func (pe PolicyEvaluator) EvaluateTagProv(ctx context.Context, gh_connection *gh
 		return slsa_types.SourceVerifiedLevels{}, "", err
 	}
 
-	// TODO: get the levels we want to use from the prov predicate...
 	outputVerifiedLevels, err := evaluateTagProv(rp.ProtectedTag, provPred)
 	if err != nil {
 		return slsa_types.SourceVerifiedLevels{}, policyPath, fmt.Errorf("error evaluating policy %s: %w", policyPath, err)

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -5,13 +5,15 @@ import "time"
 type SlsaSourceLevel string
 
 const (
-	SlsaSourceLevel1    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
-	SlsaSourceLevel2    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
-	SlsaSourceLevel3    SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
-	ContinuityEnforced                  = "CONTINUITY_ENFORCED"
-	ProvenanceAvailable                 = "PROVENANCE_AVAILABLE"
-	ReviewEnforced                      = "REVIEW_ENFORCED"
-	TagHygiene                          = "TAG_HYGIENE"
+	SlsaSourceLevel1         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
+	SlsaSourceLevel2         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
+	SlsaSourceLevel3         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
+	ContinuityEnforced                       = "CONTINUITY_ENFORCED"
+	ProvenanceAvailable                      = "PROVENANCE_AVAILABLE"
+	ReviewEnforced                           = "REVIEW_ENFORCED"
+	TagHygiene                               = "TAG_HYGIENE"
+	SourceBranchesAnnotation                 = "source_branches"
+	SourceRefsAnnotation                     = "source_refs"
 )
 
 func IsLevelHigherOrEqualTo(level1, level2 SlsaSourceLevel) bool {


### PR DESCRIPTION
The new spec says source_refs so match that.

Also added tests for the function that fetches this list (and moved the function to statement.go).