### PR TITLE
Evaluate org provided checks in policy

### DIFF
--- a/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
+++ b/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
@@ -4,7 +4,14 @@
     {
       "Name": "main",
       "Since": "2025-03-28T15:09:27.845Z",
-      "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3"
+      "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3",
+      "org_status_check_controls": [
+        {
+          "check_name": "test",
+          "property_name": "ORG_SOURCE_TESTED",
+          "Since": "2025-05-31T22:44:18.816Z"
+        }
+      ]
     }
   ]
 }

--- a/sourcetool/pkg/gh_control/checklevel.go
+++ b/sourcetool/pkg/gh_control/checklevel.go
@@ -185,10 +185,6 @@ func (ghc *GitHubConnection) computeReviewControl(ctx context.Context, rules []*
 	return nil, nil
 }
 
-func checkNameToControlName(checkName string) slsa_types.ControlName {
-	return slsa_types.ControlName(fmt.Sprintf("GH_REQUIRED_CHECK_%s", checkName))
-}
-
 func (ghc *GitHubConnection) computeRequiredChecks(ctx context.Context, ghCheckRules []*github.RequiredStatusChecksBranchRule) ([]*slsa_types.Control, error) {
 	// Only return the checks we're happy about.
 	// For now that's only stuff from the GitHub Actions app.
@@ -209,7 +205,7 @@ func (ghc *GitHubConnection) computeRequiredChecks(ctx context.Context, ghCheckR
 				continue
 			}
 			requiredChecks = append(requiredChecks, &slsa_types.Control{
-				Name: checkNameToControlName(check.Context),
+				Name: CheckNameToControlName(check.Context),
 				// TODO: get the time that indicates how long it's been enforced
 				Since: ruleset.UpdatedAt.Time,
 			})

--- a/sourcetool/pkg/gh_control/git_types.go
+++ b/sourcetool/pkg/gh_control/git_types.go
@@ -3,6 +3,8 @@ package gh_control
 import (
 	"fmt"
 	"strings"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa_types"
 )
 
 // Matches any reference type.
@@ -24,4 +26,8 @@ func GetBranchFromRef(ref string) string {
 
 func GetTagFromRef(ref string) string {
 	return strings.TrimPrefix(ref, "refs/tags/")
+}
+
+func CheckNameToControlName(checkName string) slsa_types.ControlName {
+	return slsa_types.ControlName(fmt.Sprintf("GH_REQUIRED_CHECK_%s", checkName))
 }

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -15,6 +15,7 @@ const (
 	TagHygiene               ControlName     = "TAG_HYGIENE"
 	SourceBranchesAnnotation                 = "source_branches"
 	SourceRefsAnnotation                     = "source_refs"
+	AllowedOrgPropPrefix                     = "ORG_SOURCE_"
 )
 
 func IsLevelHigherOrEqualTo(level1, level2 SlsaSourceLevel) bool {


### PR DESCRIPTION
Now evaluating org specified required checks in their policy.

If the checks are met then the associated property is embedded in the VSA.

If they aren't then evaluation fails and no VSA is issued.

Updating the slsa-source-poc repo to require the 'test' check as an example of this behavior.