### PR TITLE
Add Source Level 4 support

### DIFF
--- a/sourcetool/pkg/policy/policy_test.go
+++ b/sourcetool/pkg/policy/policy_test.go
@@ -578,7 +578,7 @@ func TestComputeEligibleSlsaLevel(t *testing.T) {
 			name:           "SLSA Level 3",
 			controls:       slsa_types.Controls{continuityEnforcedControl, provenanceAvailableControl},
 			expectedLevel:  slsa_types.SlsaSourceLevel3,
-			expectedReason: "continuity is enable and provenance is available",
+			expectedReason: "continuity is enabled and provenance is available",
 		},
 		{
 			name:           "SLSA Level 2",
@@ -623,6 +623,7 @@ func TestEvaluateBranchControls(t *testing.T) {
 
 	// Branch Policies
 	policyL3Review := ProtectedBranch{TargetSlsaSourceLevel: slsa_types.SlsaSourceLevel3, RequireReview: true, Since: fixedTime}
+	policyL4 := ProtectedBranch{TargetSlsaSourceLevel: slsa_types.SlsaSourceLevel4, Since: fixedTime}
 	policyL1NoExtras := ProtectedBranch{TargetSlsaSourceLevel: slsa_types.SlsaSourceLevel1, RequireReview: false, Since: fixedTime}
 	policyL2Review := ProtectedBranch{TargetSlsaSourceLevel: slsa_types.SlsaSourceLevel2, RequireReview: true, Since: fixedTime}
 	policyL2NoReview := ProtectedBranch{TargetSlsaSourceLevel: slsa_types.SlsaSourceLevel2, RequireReview: false, Since: fixedTime}
@@ -644,7 +645,7 @@ func TestEvaluateBranchControls(t *testing.T) {
 		expectedErrorContains string
 	}{
 		{
-			name:           "Success - All Met (L3, Review, Tags)",
+			name:           "Success - L3, Review, Tags",
 			branchPolicy:   &policyL3Review,
 			tagPolicy:      &tagHygienePolicy,
 			controls:       slsa_types.Controls{continuityEnforcedEarlier, provenanceAvailableEarlier, reviewEnforcedEarlier, tagHygieneEarlier},
@@ -652,7 +653,7 @@ func TestEvaluateBranchControls(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:           "Success - Only SLSA Level (L1)",
+			name:           "Success - L1",
 			branchPolicy:   &policyL1NoExtras,
 			tagPolicy:      &noTagHygienePolicy,
 			controls:       slsa_types.Controls{}, // L1 is met by default if policy targets L1 and other conditions pass
@@ -660,7 +661,7 @@ func TestEvaluateBranchControls(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:           "Success - SLSA & Review (L2, Review)",
+			name:           "Success - L2 & Review",
 			branchPolicy:   &policyL2Review,
 			tagPolicy:      &noTagHygienePolicy,
 			controls:       slsa_types.Controls{continuityEnforcedEarlier, reviewEnforcedEarlier}, // Provenance not needed for L2
@@ -668,11 +669,19 @@ func TestEvaluateBranchControls(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:           "Success - SLSA & Tags (L2, Tags)",
+			name:           "Success - L2 & Tags",
 			branchPolicy:   &policyL2NoReview,
 			tagPolicy:      &tagHygienePolicy,
 			controls:       slsa_types.Controls{continuityEnforcedEarlier, tagHygieneEarlier}, // Provenance not needed for L2
 			expectedLevels: slsa_types.SourceVerifiedLevels{slsa_types.ControlName(slsa_types.SlsaSourceLevel2), slsa_types.TagHygiene},
+			expectError:    false,
+		},
+		{
+			name:           "Success - L4",
+			branchPolicy:   &policyL4,
+			tagPolicy:      &tagHygienePolicy,
+			controls:       slsa_types.Controls{continuityEnforcedEarlier, provenanceAvailableEarlier, reviewEnforcedEarlier, tagHygieneEarlier},
+			expectedLevels: slsa_types.SourceVerifiedLevels{slsa_types.ControlName(slsa_types.SlsaSourceLevel4), slsa_types.TagHygiene},
 			expectError:    false,
 		},
 		{

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -9,6 +9,7 @@ const (
 	SlsaSourceLevel1         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
 	SlsaSourceLevel2         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_2"
 	SlsaSourceLevel3         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_3"
+	SlsaSourceLevel4         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_4"
 	ContinuityEnforced       ControlName     = "CONTINUITY_ENFORCED"
 	ProvenanceAvailable      ControlName     = "PROVENANCE_AVAILABLE"
 	ReviewEnforced           ControlName     = "REVIEW_ENFORCED"


### PR DESCRIPTION
Now supports Source Level 4 if a review control is enabled.

If the user specifies L4 then they must have a review control enabled in GH.  They _do not_ need to have the ReviewEnforced field in their policy eneabled.

If the user doesn't specify ReviewEnforced in their policy then REVIEW_ENFORCED won't show up in the VSA, just L4. But, if they have L4 and ReviewEnforced then they'll get _both_ SLSA_SOURCE_LEVEL_4 _and_ REVIEW_ENFORCED.