### PR TITLE
Require Tag Hygiene at L2+

### DIFF
--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -84,11 +84,11 @@ func GetRequiredControlsForLevel(level SlsaSourceLevel) []ControlName {
 	case SlsaSourceLevel1:
 		return []ControlName{}
 	case SlsaSourceLevel2:
-		return []ControlName{ContinuityEnforced}
+		return []ControlName{ContinuityEnforced, TagHygiene}
 	case SlsaSourceLevel3:
-		return []ControlName{ContinuityEnforced, ProvenanceAvailable}
+		return []ControlName{ContinuityEnforced, TagHygiene, ProvenanceAvailable}
 	case SlsaSourceLevel4:
-		return []ControlName{ContinuityEnforced, ProvenanceAvailable, ReviewEnforced}
+		return []ControlName{ContinuityEnforced, TagHygiene, ProvenanceAvailable, ReviewEnforced}
 	default:
 		return []ControlName{}
 	}

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -1,6 +1,8 @@
 package slsa_types
 
-import "time"
+import (
+	"time"
+)
 
 type ControlName string
 type SlsaSourceLevel ControlName
@@ -55,8 +57,42 @@ func (controls Controls) GetControl(name ControlName) *Control {
 	return nil
 }
 
+func (controls Controls) AreControlsAvailable(names []ControlName) bool {
+	for _, name := range names {
+		if controls.GetControl(name) == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// Returns the names of the controls.
+func (controls Controls) Names() []ControlName {
+	names := make([]ControlName, len(controls))
+	for i := range controls {
+		names[i] = controls[i].Name
+	}
+	return names
+}
+
 // These can be any string, not just SlsaLevels
 type SourceVerifiedLevels []ControlName
+
+// Returns the list of control names that must be set for the given slsa level.
+func GetRequiredControlsForLevel(level SlsaSourceLevel) []ControlName {
+	switch level {
+	case SlsaSourceLevel1:
+		return []ControlName{}
+	case SlsaSourceLevel2:
+		return []ControlName{ContinuityEnforced}
+	case SlsaSourceLevel3:
+		return []ControlName{ContinuityEnforced, ProvenanceAvailable}
+	case SlsaSourceLevel4:
+		return []ControlName{ContinuityEnforced, ProvenanceAvailable, ReviewEnforced}
+	default:
+		return []ControlName{}
+	}
+}
 
 func EarlierTime(time1, time2 time.Time) time.Time {
 	if time1.Before(time2) {


### PR DESCRIPTION
The spec now requires [Tag Hygiene at L2+](https://slsa.dev/spec/draft/source-requirements#source-control-system:~:text=%E2%9C%93-,Tag%20Hygiene,-If%20the%20SCS).

This change implements that in the tool.

Some refactoring was done to make it easier to add new control requirements at various levels.