### PR TITLE
Fix tag VSAs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -217,14 +217,8 @@ then we need to ensure the _repository_ adheres to tag hygiene requirements.
 
 #### Tag Updates
 
-TODO: Update the policy to either require tag_hygiene be set explicitly or
-make it implicit if the policy is Level 3+.
-
-TODO: We should probably figure out if we want to issue tag prov or VSAs
-if Tag Hygiene isn't enabled.
-
 This control also gets evaluated when tags are updated.  When a tag is
-updated, if policy sets 'tag_hygiene', the tool will require the control
+updated, if the policy sets 'tag_hygiene', the tool will require the control
 is enabled.  If so, it will create [Tag Provenance](#tag-provenance) for
 the tag and it will _copy_ the `verifiedLevels` from VSAs previously
 issued for the commit being tagged into a new VSA that includes this
@@ -365,9 +359,23 @@ This amounts to public declaration of SLSA adoption and allows backsliding to be
         }
       ]
     }
-  ]
+  ],
+  "protected_tag": {
+    "tag_hygiene": true,
+    "Since": "2025-02-25T17:27:49.445Z"
+  }
 }
 ```
+
+### Protecting Tags
+
+By default this tool will only issue VSAs for tags at SLSA_SOURCE_LEVEL_1 _unless_
+there is an explicit `protected_tag` setting in the policy.  This serves as a
+declaration by the org that all tags are protected.
+
+The tool does not yet support protecting only some tags. Adding support is
+tracked in
+[this issue](https://github.com/slsa-framework/slsa-source-poc/issues/129).
 
 ### Org Specified Properties
 

--- a/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
+++ b/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
@@ -13,5 +13,9 @@
         }
       ]
     }
-  ]
+  ],
+  "protected_tag": {
+    "tag_hygiene": true,
+    "Since": "2025-02-25T17:27:49.445Z"
+  }
 }

--- a/sourcetool/cmd/checktag.go
+++ b/sourcetool/cmd/checktag.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
@@ -94,6 +95,7 @@ func doCheckTag(args CheckTagArgs) {
 		log.Printf("unsigned prov: %s\n", unsignedProv)
 		log.Printf("unsigned vsa: %s\n", unsignedVsa)
 	}
+	fmt.Print(verifiedLevels)
 }
 
 func init() {

--- a/sourcetool/pkg/slsa_types/slsa_types.go
+++ b/sourcetool/pkg/slsa_types/slsa_types.go
@@ -1,6 +1,7 @@
 package slsa_types
 
 import (
+	"slices"
 	"time"
 )
 
@@ -20,6 +21,16 @@ const (
 	SourceRefsAnnotation                     = "source_refs"
 	AllowedOrgPropPrefix                     = "ORG_SOURCE_"
 )
+
+func IsSlsaSourceLevel(control ControlName) bool {
+	return slices.Contains(
+		[]ControlName{
+			ControlName(SlsaSourceLevel1),
+			ControlName(SlsaSourceLevel2),
+			ControlName(SlsaSourceLevel3),
+			ControlName(SlsaSourceLevel4)},
+		control)
+}
 
 func IsLevelHigherOrEqualTo(level1, level2 SlsaSourceLevel) bool {
 	// There's probably some fancy stuff we can get in to, but...


### PR DESCRIPTION
They weren't including the verifiedLevels from the other VSAs.

Also documenting how this works and updating the slsa-source-poc policy.

fixes #171 