### PR TITLE
Add --allow-merge-commit experimental flag

### DIFF
--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -29,6 +29,7 @@ type CheckLevelProvArgs struct {
 	expectedIssuer       string
 	expectedSan          string
 	useLocalPolicy       string
+	allowMergeCommits    bool
 }
 
 // checklevelprovCmd represents the checklevelprov command
@@ -47,6 +48,7 @@ var (
 func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 	gh_connection :=
 		gh_control.NewGhConnection(checkLevelProvArgs.owner, checkLevelProvArgs.repo, gh_control.BranchToFullRef(checkLevelProvArgs.branch)).WithAuthToken(githubToken)
+	gh_connection.Options.AllowMergeCommits = checkLevelProvArgs.allowMergeCommits
 	ctx := context.Background()
 
 	prevCommit := checkLevelProvArgs.prevCommit
@@ -135,5 +137,5 @@ func init() {
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.outputUnsignedBundle, "output_unsigned_bundle", "", "The path to write a bundle of unsigned attestations.")
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.outputSignedBundle, "output_signed_bundle", "", "The path to write a bundle of signed attestations.")
 	checklevelprovCmd.Flags().StringVar(&checkLevelProvArgs.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
-
+	checklevelprovCmd.Flags().BoolVar(&checkLevelProvArgs.allowMergeCommits, "allow-merge-commits", false, "[EXPERIMENTAL] Allow merge commits in branch")
 }

--- a/sourcetool/pkg/gh_control/connection.go
+++ b/sourcetool/pkg/gh_control/connection.go
@@ -10,6 +10,7 @@ import (
 // Manages a connection to a GitHub repository.
 type GitHubConnection struct {
 	client           *github.Client
+	Options          Options
 	owner, repo, ref string
 }
 
@@ -19,10 +20,12 @@ func NewGhConnection(owner, repo, ref string) *GitHubConnection {
 
 func NewGhConnectionWithClient(owner, repo, ref string, client *github.Client) *GitHubConnection {
 	return &GitHubConnection{
-		client: client,
-		owner:  owner,
-		repo:   repo,
-		ref:    ref}
+		client:  client,
+		owner:   owner,
+		repo:    repo,
+		ref:     ref,
+		Options: defaultOptions,
+	}
 }
 
 func (ghc *GitHubConnection) Client() *github.Client {
@@ -68,7 +71,7 @@ func (ghc *GitHubConnection) GetPriorCommit(ctx context.Context, sha string) (st
 		return "", fmt.Errorf("there is no commit earlier than %s, that isn't yet supported", sha)
 	}
 
-	if len(commit.Parents) > 1 {
+	if len(commit.Parents) > 1 && !ghc.Options.AllowMergeCommits {
 		return "", fmt.Errorf("commit %s has more than one parent (%v), which is not supported", sha, commit.Parents)
 	}
 

--- a/sourcetool/pkg/gh_control/options.go
+++ b/sourcetool/pkg/gh_control/options.go
@@ -1,0 +1,11 @@
+package gh_control
+
+var defaultOptions = Options{
+	AllowMergeCommits: false,
+}
+
+type Options struct {
+	// AllowMergeCommits causes the GitHub connector to reject merge
+	// commits when set to false.
+	AllowMergeCommits bool
+}

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -459,7 +459,7 @@ func (pe PolicyEvaluator) EvaluateControl(ctx context.Context, gh_connection *gh
 	// We want to check to ensure the repo hasn't enabled/disabled the rules since
 	// setting the 'since' field in their policy.
 	rp, policyPath, err := pe.getPolicy(ctx, gh_connection)
-	if err != nil {
+	if err != nil || rp == nil {
 		return slsa_types.SourceVerifiedLevels{}, "", err
 	}
 
@@ -485,7 +485,7 @@ func (pe PolicyEvaluator) EvaluateControl(ctx context.Context, gh_connection *gh
 // Evaluates the provenance against the policy and returns the resulting source level and policy path
 func (pe PolicyEvaluator) EvaluateSourceProv(ctx context.Context, gh_connection *gh_control.GitHubConnection, prov *spb.Statement) (slsa_types.SourceVerifiedLevels, string, error) {
 	rp, policyPath, err := pe.getPolicy(ctx, gh_connection)
-	if err != nil {
+	if err != nil || rp == nil {
 		return slsa_types.SourceVerifiedLevels{}, "", err
 	}
 


### PR DESCRIPTION
This PR adds an `--allow-merge-commit` experimental flag to allow the source tool to still traverse a repository's git history even when it has merge commits. When enabled, the tool can compute continuity and check for provenance of the previous commits. 

Note that we still don't do anything with feature branches fronted by git merge commits, this is intended to allow sourcetool to start generating provenance on the commit linear sequence. 

This also introduces an options struct to the GitHub connector with only one option (for now).

The PR adds the flag to the `checklevel` and `checklevelprov` subcommand:

```
sourcetool checklevelprov --help
Checks the given commit against policy using & creating provenance

Usage:
  sourcetool checklevelprov [flags]

Flags:
      --allow-merge-commits             [EXPERIMENTAL] Allow merge commits in branch
      --branch string                   The branch within the repository - required.
      --commit string                   The commit to check.
  -h, --help                            help for checklevelprov
      --output_signed_bundle string     The path to write a bundle of signed attestations.
      --output_unsigned_bundle string   The path to write a bundle of unsigned attestations.
      --owner string                    The GitHub repository owner - required.
      --prev_bundle_path string         Path to the file with the attestations for the previous commit (as an in-toto bundle).
      --prev_commit string              The commit to check.
      --repo string                     The GitHub repository name - required.
      --use_local_policy string         UNSAFE: Use the policy at this local path instead of the official one.

```

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>