### PR TITLE
Restore policy since date

### DIFF
--- a/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
+++ b/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
@@ -3,7 +3,7 @@
   "protected_branches": [
     {
       "Name": "main",
-      "Since": "2025-06-05T15:08:00.000Z",
+      "Since": "2025-03-28T15:09:27.845Z",
       "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3",
       "org_status_check_controls": [
         {


### PR DESCRIPTION
After fixing the workflow we're able to re-run
failed actions in commit order.  Those actions
can then create provenance & VSAs and succeed.

I've done that so now we can put the policy
back the way it was and still show continuity.