### PR TITLE
Push the policy time forward again.

### DIFF
--- a/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
+++ b/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json
@@ -3,7 +3,7 @@
   "protected_branches": [
     {
       "Name": "main",
-      "Since": "2025-03-28T15:09:27.845Z",
+      "Since": "2025-06-05T20:08:00.000Z",
       "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3",
       "org_status_check_controls": [
         {


### PR DESCRIPTION
There's an issue where we don't look at all the available provenance just the first one we find.  So even though prior commits have 'good' provenance that would meet this policy they also have 'bad' provenance that doesn't. That bad provenance is found 'first' which means we fail the policy check.  We could fix that, but it's tricky. Better to get things working again and we can resolve later.