### PR TITLE
Lint code, add config & presubmit check

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2025 The SLSA Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+name: golangci-lint
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - run: |
+          cd sourcetool && go get -d ./...
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: v2.1
+          working-directory: sourcetool

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,6 +1,7 @@
 bitbucket.org/creachadair/shell v0.0.8/go.mod h1:vINzudofoUXZSJ5tREgpy+Etyjsag3ait5WOWImEVZ0=
 cel.dev/expr v0.16.2/go.mod h1:gXngZQMkWJoSbE8mOzehJlXQyubn/Vg0vR9/F3W7iw8=
 cel.dev/expr v0.19.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cloud.google.com/go/compute v1.24.0/go.mod h1:kw1/T+h/+tK2LJK0wiPPx1intgdAM3j/g3hFDlscY40=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 cloud.google.com/go/compute/metadata v0.5.2/go.mod h1:C66sj2AluDcIqakBq/M8lw8/ybHgOZqin2obFxa/E5k=
@@ -32,6 +33,7 @@ github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSY
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/CycloneDX/cyclonedx-go v0.9.1/go.mod h1:NE/EWvzELOFlG6+ljX/QeMlVt9VKcTwu8u0ccsACEsw=
+github.com/CycloneDX/cyclonedx-go v0.9.2/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0/go.mod h1:obipzmGjfSjam60XLwGfqUkJsfiheAl+TUjG+4yzyPM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1/go.mod h1:jyqM3eLpJ3IbIFDTKVz2rF9T/xWGW0rIriGwnz8l9Tk=
@@ -57,6 +59,7 @@ github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9/go.mod
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.3/go.mod h1:UbnqO+zjqk3uIt9yCACHJ9IVNhyhOCnYk8yA19SAWrM=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.10/go.mod h1:3HKuexPDcwLWPaqpW2UR/9n8N/u/3CKcGAzSs8p8u8g=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.15/go.mod h1:CetW7bDE00QoGEmPUoZuRog07SGVAUVW6LFpNP0YfIg=
@@ -71,6 +74,7 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beevik/ntp v1.4.3/go.mod h1:Unr8Zg+2dRn7d8bHFuehIMSvvUYssHMxW3Q5Nx4RW5Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bufbuild/protocompile v0.10.0/go.mod h1:G9qQIQo0xZ6Uyj6CMNz0saGmx2so+KONo8/KrELABiY=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -80,9 +84,16 @@ github.com/buildkite/interpolate v0.1.3/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DX
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/carabiner-dev/ampel v0.0.0-20250209210344-7b306497c927/go.mod h1:KJBPGPxyllTdgWoMW/lD3KBa/KAvVznZXzgUQUyPFxs=
+github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193/go.mod h1:sQEeCRjbikSoqB1+VmZmWK2R0u2NdauEXDab+VlS8pQ=
 github.com/carabiner-dev/github v0.0.0-20250210222226-442fdacc1d16 h1:6ESg7ESScHJp/e4zHO1a1y6XDAJYTcK9N06mqbqBvUg=
 github.com/carabiner-dev/github v0.0.0-20250210222226-442fdacc1d16/go.mod h1:hAfka+26SmZJoTfpWUnIeQUVKFYcT45RUPXqBsqxWpU=
+github.com/carabiner-dev/github v0.2.2/go.mod h1:J7VqMAUewwRQH6r6HMDmVNf39f/z7H5iyTzOfC8am9A=
 github.com/carabiner-dev/hasher v0.1.0/go.mod h1:+X5f8ts4Q/ubkmsWQGzCQwPxtJx39AoqoT/IlDR7M9Q=
+github.com/carabiner-dev/hasher v0.2.2/go.mod h1:bM7reKZ5gGEY4Bbcd3Lr2KhrtqNkEhJOmQ4ptGasnFY=
+github.com/carabiner-dev/jsonl v0.2.0/go.mod h1:H0ac1z6a6AEvRx1+laZrztAdGoYuB/CVlGXK5nHHQyI=
+github.com/carabiner-dev/openeox v0.0.0-20250430212020-e3a5beb42ddd/go.mod h1:40KVT1ee6L8VoWT44RvAQ0AtG91MFr5/zBzTmNiXQWY=
+github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
+github.com/carabiner-dev/vcslocator v0.2.2/go.mod h1:/67gubbzxtg25MIg/eRlmBkHExFDqyVZ2Dj0VJatHwE=
 github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e/go.mod h1:V284PjgVwSk4ETmz84rpu9ehpGg7swlIH8npP9k2bGw=
 github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8/go.mod h1:AZIh1CCnMrcVm6afFf96PBvE2MRpWFco91z8ObJtgDY=
 github.com/cavaliergopher/cpio v1.0.1/go.mod h1:pBdaqQjnvXxdS/6CvNDwIANIFSP0xRKI16PX4xejRQc=
@@ -104,6 +115,7 @@ github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5
 github.com/cli/shurcooL-graphql v0.0.4 h1:6MogPnQJLjKkaXPyGqPRXOI2qCsQdqNfUY1QSJu2GuY=
 github.com/cli/shurcooL-graphql v0.0.4/go.mod h1:3waN4u02FiZivIV+p1y4d0Jo1jc6BViMA73C+sZo2fk=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
+github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
@@ -133,7 +145,9 @@ github.com/eggsampler/acme/v3 v3.6.0/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/proto v1.12.1/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/envoyproxy/go-control-plane v0.13.1/go.mod h1:X45hY0mufo6Fd0KW3rqsGvQMw58jvjymeCzBU3mWyHw=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
+github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -165,6 +179,7 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/cel-go v0.22.1/go.mod h1:BuznPXXfQDpXKWQ9sPW3TzlAJN5zzFe+i9tIs0yC4s8=
@@ -252,6 +267,7 @@ github.com/nats-io/nats.go v1.34.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF
 github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
@@ -269,7 +285,9 @@ github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9
 github.com/open-policy-agent/opa v0.68.0/go.mod h1:5E5SvaPwTpwt2WM177I9Z3eT7qUpmOGjk1ZdHs+TZ4w=
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/openvex/go-vex v0.2.5/go.mod h1:j+oadBxSUELkrKh4NfNb+BPo77U3q7gdKME88IO/0Wo=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
+github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -280,6 +298,7 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
 github.com/prometheus/prometheus v0.51.0/go.mod h1:yv4MwOn3yHMQ6MZGHPg/U7Fcyqf+rxqiZfSur6myVtc=
 github.com/protobom/protobom v0.5.0/go.mod h1:HL47tggz7SXYXgNm3WjQQrWB6iOirYnrATsXAEyTUkI=
+github.com/protobom/protobom v0.5.2/go.mod h1:io5yUKGWBqGa2sx1n7aVPg+tG13Hun9oMz4Y+EjNjjc=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
@@ -294,10 +313,12 @@ github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWR
 github.com/sigstore/cosign/v2 v2.4.1/go.mod h1:GvzjBeUKigI+XYnsoVQDmMAsMMc6engxztRSuxE+x9I=
 github.com/sigstore/fulcio v1.6.3/go.mod h1:5SDgLn7BOUVLKe1DwOEX3wkWFu5qEmhUlWm+SFf0GH8=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/spdx/tools-golang v0.5.5/go.mod h1:MVIsXx8ZZzaRWNQpUDhC4Dud34edUYJYecciXgrw5vE=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spiffe/go-spiffe/v2 v2.1.3/go.mod h1:eVDqm9xFvyqao6C+eQensb9ZPkyNEeaUbqbBpOhBnNk=
 github.com/spiffe/go-spiffe/v2 v2.3.0/go.mod h1:Oxsaio7DBgSNqhAO9i/9tLClaVlfRok7zvJnTV8ZyIY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
@@ -355,6 +376,7 @@ go.etcd.io/etcd/tests/v3 v3.5.17/go.mod h1:y3RTU0exZyj92+ZaG/wgUIMXXlnJlfNpni87t
 go.etcd.io/etcd/v3 v3.5.17/go.mod h1:eL6ktWWJRCZ/C5Ak8SFCOfMUQcZjzasSKEtzkpSB6aM=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/detectors/gcp v1.32.0/go.mod h1:TVqo0Sda4Cv8gCIixd7LuLwW4EylumVWfhjZJjDD4DU=
+go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.57.0/go.mod h1:wZcGmeVO9nzP67aYSLDqXNWK87EZWhi7JWj1v7ZXf94=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0/go.mod h1:OQFyQVrDlbe+R7xrEyDr/2Wr67Ol0hRUgsfA+V5A95s=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0/go.mod h1:cpgtDBaqD/6ok/UG0jT15/uKjAY8mRA53diogHBg3UI=
@@ -362,6 +384,7 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0/go.mod h
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0/go.mod h1:wAy0T/dUbs468uOlkT31xjvqQgEVXv58BRFWEgn5v/0=
 go.opentelemetry.io/otel/sdk v1.32.0/go.mod h1:LqgegDBjKMmb2GC6/PrTnteJG39I8/vJCAP9LlJXEjU=
 go.opentelemetry.io/otel/sdk/metric v1.32.0/go.mod h1:PWeZlq0zt9YkYAp3gjKZ0eicRYvOh1Gd+X99x6GHpCQ=
+go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
 go.opentelemetry.io/proto/otlp v1.4.0/go.mod h1:PPBWZIP98o2ElSqI35IHfu7hIhSwvc5N38Jw8pXuGFY=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -411,6 +434,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -448,8 +472,10 @@ k8s.io/apimachinery v0.32.1/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDEl
 k8s.io/client-go v0.28.3/go.mod h1:LTykbBp9gsA7SwqirlCXBWtK0guzfhpoW4qSm7i9dxo=
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/release-sdk v0.12.1/go.mod h1:nnB4tt1g0VXMUCIYzDzPVqNI896OQrWipE6WbyZ6FSk=
+sigs.k8s.io/release-sdk v0.12.2/go.mod h1:tlJgWPJLeRbWOvcyq1XrCZmLe8Yfn3H5U/LNtmBa0Nc=
 sigs.k8s.io/release-utils v0.8.5/go.mod h1:qsm5bdxdgoHkD8HsXpgme2/c3mdsNaiV53Sz2HmKeJA=
 sigs.k8s.io/release-utils v0.9.0/go.mod h1:xZoCJyajMJ0wtgGXWuznbC1r9dw7iJzMp/+dCkf1UGw=
 sigs.k8s.io/release-utils v0.11.0/go.mod h1:wAlXz8xruzvqZUsorI64dZ3lbkiDnYSlI4IYC6l2yEA=

--- a/sourcetool/.golangci.yaml
+++ b/sourcetool/.golangci.yaml
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright 2025 The SLSA Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+version: "2"
+run:
+  concurrency: 6
+  timeout: 5m
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    # - golines
+  settings: 
+    gci:
+      no-inline-comments: false
+      no-prefix-comments: true
+      sections:
+        - standard
+        - default
+        - prefix(github.com/slsa-framework/slsa-source-poc)
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - canonicalheader
+    - containedctx
+    - contextcheck
+    - copyloopvar
+    - decorder
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - fatcontext
+    - forcetypeassert
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - goconst
+    - gocritic
+    - gocyclo
+    # - godot
+    - godox
+    - goheader
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosmopolitan
+    - govet
+    - grouper
+    - iface
+    - importas
+    - ineffassign
+    - intrange
+    - loggercheck
+    - makezero
+    - mirror
+    - misspell
+    - musttag
+    - nakedret
+    - nilerr
+    - nilnesserr
+    # - nlreturn
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    # - perfsprint
+    - prealloc
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    - recvcheck
+    # - revive
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - tagalign
+    - testableexamples
+    - testifylint
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
+    # - wsl
+    - zerologlint
+
+  settings:
+    gocyclo:
+      min-complexity: 35
+    godox:
+      keywords:
+        - BUG
+        - FIXME
+        - HACK
+    gosmopolitan:
+      # Allow and ignore `time.Local` usages.
+      #
+      # Default: false
+      allow-time-local: true
+    perfsprint:
+      integer-format: false
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocritic:
+      enabled-checks:
+        # Diagnostic
+        - commentedOutCode
+        - nilValReturn
+        - sloppyReassign
+        - weakCond
+        - octalLiteral
+
+        # Performance
+        - appendCombine
+        - equalFold
+        - hugeParam
+        - indexAlloc
+        - rangeExprCopy
+        - rangeValCopy
+
+        # Style
+        - boolExprSimplify
+        - commentedOutImport
+        - docStub
+        - emptyFallthrough
+        - emptyStringTest
+        - hexLiteral
+        - methodExprCall
+        - stringXbytes
+        - typeAssertChain
+        - unlabelStmt
+        - yodaStyleExpr
+        # - ifElseChain
+
+        # Opinionated
+        - builtinShadow
+        - importShadow
+        - initClause
+        - nestingReduce
+        - paramTypeCombine
+        - ptrToRefParam
+        - typeUnparen
+        - unnamedResult
+        - unnecessaryBlock
+    gosec:
+      excludes:
+        - G304
+    nolintlint:
+      # Enable to ensure that nolint directives are all used. Default is true.
+      allow-unused: false
+      # Exclude following linters from requiring an explanation.  Default is [].
+      allow-no-explanation: []
+      # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+      # TODO(lint): Enforce explanations for `nolint` directives
+      require-explanation: false
+      # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+      require-specific: true

--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -73,7 +73,7 @@ func doCheckLevel(cla *CheckLevelArgs) {
 		log.Fatal(err)
 	}
 	if cla.outputUnsignedVsa != "" {
-		if err = os.WriteFile(cla.outputUnsignedVsa, []byte(unsignedVsa), 0o644); err != nil {
+		if err = os.WriteFile(cla.outputUnsignedVsa, []byte(unsignedVsa), 0o644); err != nil { //nolint:gosec
 			log.Fatal(err)
 		}
 	}
@@ -84,7 +84,7 @@ func doCheckLevel(cla *CheckLevelArgs) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		err = os.WriteFile(cla.outputVsa, []byte(signedVsa), 0o644)
+		err = os.WriteFile(cla.outputVsa, []byte(signedVsa), 0o644) //nolint:gosec
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/sourcetool/cmd/checklevel.go
+++ b/sourcetool/cmd/checklevel.go
@@ -10,11 +10,11 @@ import (
 	"log"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
-
-	"github.com/spf13/cobra"
 )
 
 type CheckLevelArgs struct {
@@ -73,7 +73,7 @@ func doCheckLevel(cla *CheckLevelArgs) {
 		log.Fatal(err)
 	}
 	if cla.outputUnsignedVsa != "" {
-		if err = os.WriteFile(cla.outputUnsignedVsa, []byte(unsignedVsa), 0644); err != nil {
+		if err = os.WriteFile(cla.outputUnsignedVsa, []byte(unsignedVsa), 0o644); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -84,7 +84,7 @@ func doCheckLevel(cla *CheckLevelArgs) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		err = os.WriteFile(cla.outputVsa, []byte(signedVsa), 0644)
+		err = os.WriteFile(cla.outputVsa, []byte(signedVsa), 0o644)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -9,12 +9,12 @@ import (
 	"log"
 	"os"
 
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
-	"google.golang.org/protobuf/encoding/protojson"
-
-	"github.com/spf13/cobra"
 )
 
 type CheckLevelProvArgs struct {
@@ -46,8 +46,7 @@ var (
 )
 
 func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
-	ghconnection :=
-		ghcontrol.NewGhConnection(checkLevelProvArgs.owner, checkLevelProvArgs.repo, ghcontrol.BranchToFullRef(checkLevelProvArgs.branch)).WithAuthToken(githubToken)
+	ghconnection := ghcontrol.NewGhConnection(checkLevelProvArgs.owner, checkLevelProvArgs.repo, ghcontrol.BranchToFullRef(checkLevelProvArgs.branch)).WithAuthToken(githubToken)
 	ghconnection.Options.AllowMergeCommits = checkLevelProvArgs.allowMergeCommits
 	ctx := context.Background()
 
@@ -87,18 +86,18 @@ func doCheckLevelProv(checkLevelProvArgs CheckLevelProvArgs) {
 
 	// Store both the unsigned provenance and vsa
 	if checkLevelProvArgs.outputUnsignedBundle != "" {
-		f, err := os.OpenFile(checkLevelProvArgs.outputUnsignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		f, err := os.OpenFile(checkLevelProvArgs.outputUnsignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 		if err != nil {
 			log.Fatal(err)
 		}
 		defer f.Close()
 
-		f.WriteString(string(unsignedProv))
+		f.Write(unsignedProv)
 		f.WriteString("\n")
 		f.WriteString(unsignedVsa)
 		f.WriteString("\n")
 	} else if checkLevelProvArgs.outputSignedBundle != "" {
-		f, err := os.OpenFile(checkLevelProvArgs.outputSignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		f, err := os.OpenFile(checkLevelProvArgs.outputSignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/sourcetool/cmd/checktag.go
+++ b/sourcetool/cmd/checktag.go
@@ -9,11 +9,12 @@ import (
 	"log"
 	"os"
 
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
-	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type CheckTagArgs struct {
@@ -39,8 +40,7 @@ var (
 )
 
 func doCheckTag(args CheckTagArgs) {
-	ghconnection :=
-		ghcontrol.NewGhConnection(args.owner, args.repo, ghcontrol.TagToFullRef(args.tagName)).WithAuthToken(githubToken)
+	ghconnection := ghcontrol.NewGhConnection(args.owner, args.repo, ghcontrol.TagToFullRef(args.tagName)).WithAuthToken(githubToken)
 	ctx := context.Background()
 	verifier := getVerifier()
 
@@ -71,7 +71,7 @@ func doCheckTag(args CheckTagArgs) {
 	}
 
 	if args.outputSignedBundle != "" {
-		f, err := os.OpenFile(args.outputSignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		f, err := os.OpenFile(args.outputSignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -108,5 +108,4 @@ func init() {
 	checktagCmd.Flags().StringVar(&checkTagArgs.actor, "actor", "", "The username of the actor that pushed the tag.")
 	checktagCmd.Flags().StringVar(&checkTagArgs.outputSignedBundle, "output_signed_bundle", "", "The path to write a bundle of signed attestations.")
 	checktagCmd.Flags().StringVar(&checkTagArgs.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
-
 }

--- a/sourcetool/cmd/checktag.go
+++ b/sourcetool/cmd/checktag.go
@@ -28,18 +28,21 @@ type CheckTagArgs struct {
 }
 
 var (
-	checkTagArgs CheckTagArgs
+	checkTagArgs = &CheckTagArgs{}
+
 	// checktagCmd represents the checktag command
 	checktagCmd = &cobra.Command{
 		Use:   "checktag",
 		Short: "Checks to see if the tag operation should be allowed and issues a VSA",
 		Run: func(cmd *cobra.Command, args []string) {
-			doCheckTag(checkTagArgs)
+			if err := doCheckTag(checkTagArgs); err != nil {
+				log.Fatal(err)
+			}
 		},
 	}
 )
 
-func doCheckTag(args CheckTagArgs) {
+func doCheckTag(args *CheckTagArgs) error {
 	ghconnection := ghcontrol.NewGhConnection(args.owner, args.repo, ghcontrol.TagToFullRef(args.tagName)).WithAuthToken(githubToken)
 	ctx := context.Background()
 	verifier := getVerifier()
@@ -48,7 +51,7 @@ func doCheckTag(args CheckTagArgs) {
 	pa := attest.NewProvenanceAttestor(ghconnection, verifier)
 	prov, err := pa.CreateTagProvenance(ctx, args.commit, ghcontrol.TagToFullRef(args.tagName), args.actor)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// check p against policy
@@ -56,46 +59,46 @@ func doCheckTag(args CheckTagArgs) {
 	pe.UseLocalPolicy = args.useLocalPolicy
 	verifiedLevels, policyPath, err := pe.EvaluateTagProv(ctx, ghconnection, prov)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// create vsa
 	unsignedVsa, err := attest.CreateUnsignedSourceVsa(ghconnection.GetRepoUri(), ghconnection.GetFullRef(), args.commit, verifiedLevels, policyPath)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	unsignedProv, err := protojson.Marshal(prov)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	if args.outputSignedBundle != "" {
-		f, err := os.OpenFile(args.outputSignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+		f, err := os.OpenFile(args.outputSignedBundle, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644) //nolint:gosec
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
-		defer f.Close()
+		defer f.Close() //nolint:errcheck
 
 		signedProv, err := attest.Sign(string(unsignedProv))
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		signedVsa, err := attest.Sign(unsignedVsa)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
-		f.WriteString(signedProv)
-		f.WriteString("\n")
-		f.WriteString(signedVsa)
-		f.WriteString("\n")
+		if _, err := f.WriteString(signedProv + "\n" + signedVsa + "\n"); err != nil {
+			return fmt.Errorf("writing bundledata: %w", err)
+		}
 	} else {
 		log.Printf("unsigned prov: %s\n", unsignedProv)
 		log.Printf("unsigned vsa: %s\n", unsignedVsa)
 	}
 	fmt.Print(verifiedLevels)
+	return nil
 }
 
 func init() {

--- a/sourcetool/cmd/createpolicy.go
+++ b/sourcetool/cmd/createpolicy.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/spf13/cobra"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
-
-	"github.com/spf13/cobra"
 )
 
 type CreatePolicyArgs struct {

--- a/sourcetool/cmd/prov.go
+++ b/sourcetool/cmd/prov.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/spf13/cobra"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
 )
 
 type ProvArgs struct {

--- a/sourcetool/cmd/root.go
+++ b/sourcetool/cmd/root.go
@@ -6,8 +6,9 @@ package cmd
 import (
 	"os"
 
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/spf13/cobra"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 )
 
 var (
@@ -59,5 +60,4 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&githubToken, "github_token", "", "the github token to use for auth")
 	rootCmd.PersistentFlags().StringVar(&expectedIssuer, "expected_issuer", "", "The expected issuer of attestations.")
 	rootCmd.PersistentFlags().StringVar(&expectedSan, "expected_san", "", "The expect san of attestations.")
-
 }

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/spf13/cobra"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
-	"github.com/spf13/cobra"
 )
 
 type VerifyCommitArgs struct {
@@ -55,7 +56,7 @@ func doVerifyCommit(commit, owner, repo, branch, tag string) {
 		return
 	}
 
-	fmt.Printf("SUCCESS: commit %s verified with %v\n", commit, vsaPred.VerifiedLevels)
+	fmt.Printf("SUCCESS: commit %s verified with %v\n", commit, vsaPred.GetVerifiedLevels())
 }
 
 func init() {
@@ -66,5 +67,4 @@ func init() {
 	verifycommitCmd.Flags().StringVar(&verifyCommitArgs.branch, "branch", "", "The branch within the repository.")
 	verifycommitCmd.Flags().StringVar(&verifyCommitArgs.tag, "tag", "", "The tag within the repository.")
 	verifycommitCmd.Flags().StringVar(&verifyCommitArgs.commit, "commit", "", "The commit to check - required.")
-
 }

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -36,11 +36,12 @@ func doVerifyCommit(commit, owner, repo, branch, tag string) {
 	}
 
 	ref := ""
-	if branch != "" {
+	switch {
+	case branch != "":
 		ref = ghcontrol.BranchToFullRef(branch)
-	} else if tag != "" {
+	case tag != "":
 		ref = ghcontrol.TagToFullRef(tag)
-	} else {
+	default:
 		log.Fatal("Must specify either branch or tag.")
 	}
 

--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -19,8 +19,10 @@ import (
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
-const SourceProvPredicateType = "https://github.com/slsa-framework/slsa-source-poc/source-provenance/v1-draft"
-const TagProvPredicateType = "https://github.com/slsa-framework/slsa-source-poc/tag-provenance/v1-draft"
+const (
+	SourceProvPredicateType = "https://github.com/slsa-framework/slsa-source-poc/source-provenance/v1-draft"
+	TagProvPredicateType    = "https://github.com/slsa-framework/slsa-source-poc/tag-provenance/v1-draft"
+)
 
 // The predicate that encodes source provenance data.
 // The git commit this corresponds to is encoded in the surrounding statement.
@@ -67,13 +69,13 @@ func GetSourceProvPred(statement *spb.Statement) (*SourceProvenancePred, error) 
 	if statement == nil {
 		return nil, errors.New("nil statement")
 	}
-	if statement.PredicateType != SourceProvPredicateType {
-		return nil, fmt.Errorf("unsupported predicate type: %s", statement.PredicateType)
+	if statement.GetPredicateType() != SourceProvPredicateType {
+		return nil, fmt.Errorf("unsupported predicate type: %s", statement.GetPredicateType())
 	}
-	if statement.Predicate == nil {
+	if statement.GetPredicate() == nil {
 		return nil, errors.New("nil predicate in statement")
 	}
-	predJson, err := protojson.Marshal(statement.Predicate)
+	predJson, err := protojson.Marshal(statement.GetPredicate())
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal predicate to JSON: %w", err)
 	}
@@ -94,13 +96,13 @@ func GetTagProvPred(statement *spb.Statement) (*TagProvenancePred, error) {
 	if statement == nil {
 		return nil, errors.New("nil statement")
 	}
-	if statement.PredicateType != TagProvPredicateType {
-		return nil, fmt.Errorf("unsupported predicate type: %s", statement.PredicateType)
+	if statement.GetPredicateType() != TagProvPredicateType {
+		return nil, fmt.Errorf("unsupported predicate type: %s", statement.GetPredicateType())
 	}
-	if statement.Predicate == nil {
+	if statement.GetPredicate() == nil {
 		return nil, errors.New("nil predicate in statement")
 	}
-	predJson, err := protojson.Marshal(statement.Predicate)
+	predJson, err := protojson.Marshal(statement.GetPredicate())
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal predicate to JSON: %w", err)
 	}
@@ -311,7 +313,7 @@ func (pa ProvenanceAttestor) CreateTagProvenance(ctx context.Context, commit, re
 		VsaSummaries: []VsaSummary{
 			{
 				SourceRefs:     vsaRefs,
-				VerifiedLevels: slsa.StringsToControlNames(vsaPred.VerifiedLevels),
+				VerifiedLevels: slsa.StringsToControlNames(vsaPred.GetVerifiedLevels()),
 			},
 		},
 	}

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -89,7 +89,7 @@ func timesEqualWithinMargin(t1, t2 time.Time, margin time.Duration) bool {
 	return diff <= margin
 }
 
-func assertTagProvPredsEqual(t *testing.T, actual, expected TagProvenancePred) {
+func assertTagProvPredsEqual(t *testing.T, actual, expected *TagProvenancePred) {
 	if actual.Actor != expected.Actor {
 		t.Errorf("Actor %v does not match expected value %v", actual.Actor, expected.Actor)
 	}
@@ -173,5 +173,5 @@ func TestCreateTagProvenance(t *testing.T) {
 		},
 	}
 
-	assertTagProvPredsEqual(t, *tagPred, expectedPred)
+	assertTagProvPredsEqual(t, tagPred, &expectedPred)
 }

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -1,13 +1,13 @@
 package attest
 
 import (
-	"context"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/google/go-github/v69/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/testsupport"
@@ -46,7 +46,8 @@ func newNotesContent(content string) *github.RepositoryContent {
 }
 
 func newTagHygieneRulesetsResponse(id int64, target github.RulesetTarget, enforcement github.RulesetEnforcement,
-	updatedAt time.Time) *github.RepositoryRuleset {
+	updatedAt time.Time,
+) *github.RepositoryRuleset {
 	return &github.RepositoryRuleset{
 		ID:          github.Ptr(id),
 		Target:      github.Ptr(target),
@@ -108,7 +109,7 @@ func assertTagProvPredsEqual(t *testing.T, actual, expected TagProvenancePred) {
 	if len(actual.Controls) != len(expected.Controls) {
 		t.Errorf("Control %v does not match expected value %v", actual.Controls, expected.Controls)
 	} else {
-		for ci, _ := range actual.Controls {
+		for ci := range actual.Controls {
 			if !timesEqualWithinMargin(actual.Controls[ci].Since, expected.Controls[ci].Since, time.Second) {
 				t.Errorf("control at [%d]'s time %v does not match expected time %v", ci,
 					actual.Controls[ci].Since, expected.Controls[ci].Since)
@@ -131,7 +132,7 @@ func TestCreateTagProvenance(t *testing.T) {
 
 	pa := NewProvenanceAttestor(ghc, verifier)
 
-	stmt, err := pa.CreateTagProvenance(context.Background(), "abc123", "refs/tags/v1", "the-tag-pusher")
+	stmt, err := pa.CreateTagProvenance(t.Context(), "abc123", "refs/tags/v1", "the-tag-pusher")
 	if err != nil {
 		t.Fatalf("error creating tag prov %v", err)
 	}
@@ -140,12 +141,12 @@ func TestCreateTagProvenance(t *testing.T) {
 		t.Fatalf("returned statement is nil")
 	}
 
-	if stmt.PredicateType != TagProvPredicateType {
-		t.Errorf("statement pred type %v does not match expected %v", stmt.PredicateType, TagProvPredicateType)
+	if stmt.GetPredicateType() != TagProvPredicateType {
+		t.Errorf("statement pred type %v does not match expected %v", stmt.GetPredicateType(), TagProvPredicateType)
 	}
 
 	if !DoesSubjectIncludeCommit(stmt, "abc123") {
-		t.Errorf("statement subject %v does not match expected %v", stmt.Subject, "abc123")
+		t.Errorf("statement subject %v does not match expected %v", stmt.GetSubject(), "abc123")
 	}
 
 	tagPred, err := GetTagProvPred(stmt)

--- a/sourcetool/pkg/attest/statement.go
+++ b/sourcetool/pkg/attest/statement.go
@@ -22,7 +22,7 @@ func NewBundleReader(reader *bufio.Reader, verifier Verifier) *BundleReader {
 	return &BundleReader{reader: reader, verifier: verifier}
 }
 
-func (br BundleReader) convertLineToStatement(line string) (*spb.Statement, error) {
+func (br *BundleReader) convertLineToStatement(line string) (*spb.Statement, error) {
 	// Is this a sigstore bundle with a statement?
 	vr, err := br.verifier.Verify(line)
 	if err == nil {

--- a/sourcetool/pkg/attest/statement.go
+++ b/sourcetool/pkg/attest/statement.go
@@ -2,13 +2,15 @@ package attest
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 
 	spb "github.com/in-toto/attestation/go/v1"
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
 type BundleReader struct {
@@ -43,11 +45,11 @@ func GetSourceRefsForCommit(vsaStatement *spb.Statement, commit string) ([]strin
 		return []string{}, fmt.Errorf("statement \n%v\n does not match commit %s", StatementToString(vsaStatement), commit)
 	}
 	annotations := subject.GetAnnotations()
-	sourceRefs, ok := annotations.Fields[slsa.SourceRefsAnnotation]
+	sourceRefs, ok := annotations.GetFields()[slsa.SourceRefsAnnotation]
 	if !ok {
 		// This used to be called 'source_branches', maybe this is an old VSA.
 		// TODO: remove once we're not worried about backward compatibility.
-		sourceRefs, ok = annotations.Fields[slsa.SourceBranchesAnnotation]
+		sourceRefs, ok = annotations.GetFields()[slsa.SourceBranchesAnnotation]
 		if !ok {
 			return []string{}, fmt.Errorf("no source_refs or source_branches annotation in VSA subject")
 		}
@@ -55,7 +57,7 @@ func GetSourceRefsForCommit(vsaStatement *spb.Statement, commit string) ([]strin
 
 	protoRefs := sourceRefs.GetListValue()
 	stringRefs := []string{}
-	for _, ref := range protoRefs.Values {
+	for _, ref := range protoRefs.GetValues() {
 		stringRefs = append(stringRefs, ref.GetStringValue())
 	}
 	return stringRefs, nil
@@ -65,8 +67,8 @@ type StatementMatcher func(*spb.Statement) bool
 
 func MatchesTypeAndCommit(predicateType, commit string) StatementMatcher {
 	return func(statement *spb.Statement) bool {
-		if statement.PredicateType != predicateType {
-			log.Printf("statement predicate type (%s) doesn't match %s", statement.PredicateType, predicateType)
+		if statement.GetPredicateType() != predicateType {
+			log.Printf("statement predicate type (%s) doesn't match %s", statement.GetPredicateType(), predicateType)
 			return false
 		}
 		if !DoesSubjectIncludeCommit(statement, commit) {
@@ -86,7 +88,7 @@ func (br *BundleReader) ReadStatement(matcher StatementMatcher) (*spb.Statement,
 		line, err := br.reader.ReadString('\n')
 		if err != nil {
 			// Handle end of file gracefully
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				return nil, err
 			}
 			if line == "" {
@@ -121,8 +123,8 @@ func DoesSubjectIncludeCommit(statement *spb.Statement, commit string) bool {
 // Returns the _first_ subject that includes the commit.
 // TODO: add support for multiple subjects...
 func GetSubjectForCommit(statement *spb.Statement, commit string) *spb.ResourceDescriptor {
-	for _, subject := range statement.Subject {
-		if subject.Digest["gitCommit"] == commit {
+	for _, subject := range statement.GetSubject() {
+		if subject.GetDigest()["gitCommit"] == commit {
 			return subject
 		}
 	}

--- a/sourcetool/pkg/attest/statement_test.go
+++ b/sourcetool/pkg/attest/statement_test.go
@@ -33,7 +33,7 @@ func newStatement(commit string, annotation *map[string]any) (*spb.Statement, er
 
 func stringToAnyArray(valArray []string) []any {
 	aa := make([]any, len(valArray))
-	for i, _ := range valArray {
+	for i := range valArray {
 		aa[i] = valArray[i]
 	}
 	return aa

--- a/sourcetool/pkg/attest/statement_test.go
+++ b/sourcetool/pkg/attest/statement_test.go
@@ -9,10 +9,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func newStatement(commit string, annotation *map[string]any) (*spb.Statement, error) {
+func newStatement(commit string, annotation map[string]any) (*spb.Statement, error) {
 	var sub []*spb.ResourceDescriptor
 	if annotation != nil {
-		annotationStruct, err := structpb.NewStruct(*annotation)
+		annotationStruct, err := structpb.NewStruct(annotation)
 		if err != nil {
 			return nil, fmt.Errorf("creating struct from map: %w", err)
 		}
@@ -86,7 +86,7 @@ func TestGetSourceRefsForCommit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stmt, err := newStatement("abc123", &map[string]any{tt.annotationName: stringToAnyArray(tt.refs)})
+			stmt, err := newStatement("abc123", map[string]any{tt.annotationName: stringToAnyArray(tt.refs)})
 			if err != nil {
 				t.Fatalf("error creating statement: %v", err)
 			}

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -9,11 +9,12 @@ import (
 
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	spb "github.com/in-toto/attestation/go/v1"
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
 const VsaPredicateType = "https://slsa.dev/verification_summary/v1"
@@ -22,7 +23,8 @@ func CreateUnsignedSourceVsa(repoUri, ref, commit string, verifiedLevels slsa.So
 	resourceUri := fmt.Sprintf("git+%s", repoUri)
 	vsaPred := &vpb.VerificationSummary{
 		Verifier: &vpb.VerificationSummary_Verifier{
-			Id: "https://github.com/slsa-framework/slsa-source-poc"},
+			Id: "https://github.com/slsa-framework/slsa-source-poc",
+		},
 		TimeVerified:       timestamppb.Now(),
 		ResourceUri:        resourceUri,
 		Policy:             &vpb.VerificationSummary_Policy{Uri: policy},
@@ -80,7 +82,7 @@ func GetVsa(ctx context.Context, ghc *ghcontrol.GitHubConnection, verifier Verif
 }
 
 func getVsaPred(statement *spb.Statement) (*vpb.VerificationSummary, error) {
-	predJson, err := protojson.Marshal(statement.Predicate)
+	predJson, err := protojson.Marshal(statement.GetPredicate())
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +98,8 @@ func getVsaPred(statement *spb.Statement) (*vpb.VerificationSummary, error) {
 
 func MatchesTypeCommitAndRef(predicateType, commit, targetRef string) StatementMatcher {
 	return func(statement *spb.Statement) bool {
-		if statement.PredicateType != predicateType {
-			log.Printf("statement predicate type (%s) doesn't match %s", statement.PredicateType, predicateType)
+		if statement.GetPredicateType() != predicateType {
+			log.Printf("statement predicate type (%s) doesn't match %s", statement.GetPredicateType(), predicateType)
 			return false
 		}
 		refs, err := GetSourceRefsForCommit(statement, commit)

--- a/sourcetool/pkg/ghcontrol/checklevel.go
+++ b/sourcetool/pkg/ghcontrol/checklevel.go
@@ -12,6 +12,10 @@ import (
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
+const (
+	EnforcementActive = "active"
+)
+
 type actor struct {
 	Login string `json:"login"`
 }
@@ -124,7 +128,7 @@ func enforcesTagHygiene(ruleset *github.RepositoryRuleset) bool {
 	return false
 }
 
-func (ghc *GitHubConnection) computeTagHygieneControl(ctx context.Context, commit string, allRulesets []*github.RepositoryRuleset, activityTime *time.Time) (*slsa.Control, error) {
+func (ghc *GitHubConnection) computeTagHygieneControl(ctx context.Context, _ string, allRulesets []*github.RepositoryRuleset, activityTime *time.Time) (*slsa.Control, error) {
 	var validRuleset *github.RepositoryRuleset
 	for _, ruleset := range allRulesets {
 		if *ruleset.Target != github.RulesetTargetTag {
@@ -171,7 +175,7 @@ func (ghc *GitHubConnection) computeReviewControl(ctx context.Context, rules []*
 			if err != nil {
 				return nil, err
 			}
-			if ruleset.Enforcement == "active" {
+			if ruleset.Enforcement == EnforcementActive {
 				if oldestActive == nil || oldestActive.UpdatedAt.After(ruleset.UpdatedAt.Time) {
 					oldestActive = ruleset
 				}
@@ -195,7 +199,7 @@ func (ghc *GitHubConnection) computeRequiredChecks(ctx context.Context, ghCheckR
 		if err != nil {
 			return nil, err
 		}
-		if ruleset.Enforcement != "active" {
+		if ruleset.Enforcement != EnforcementActive {
 			// Only look at rules being enforced.
 			continue
 		}
@@ -221,7 +225,7 @@ func (ghc *GitHubConnection) getOldestActiveRule(ctx context.Context, rules []*g
 		if err != nil {
 			return nil, err
 		}
-		if ruleset.Enforcement == "active" {
+		if ruleset.Enforcement == EnforcementActive {
 			if oldestActive == nil || oldestActive.UpdatedAt.After(ruleset.UpdatedAt.Time) {
 				oldestActive = ruleset
 			}

--- a/sourcetool/pkg/ghcontrol/checklevel.go
+++ b/sourcetool/pkg/ghcontrol/checklevel.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v69/github"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
@@ -97,7 +98,7 @@ func (ghc *GitHubConnection) computeContinuityControl(ctx context.Context, commi
 	}
 
 	newestRule := oldestDeletion
-	if newestRule.UpdatedAt.Time.Before(oldestNoFf.UpdatedAt.Time) {
+	if newestRule.UpdatedAt.Before(oldestNoFf.UpdatedAt.Time) {
 		newestRule = oldestNoFf
 	}
 
@@ -171,7 +172,7 @@ func (ghc *GitHubConnection) computeReviewControl(ctx context.Context, rules []*
 				return nil, err
 			}
 			if ruleset.Enforcement == "active" {
-				if oldestActive == nil || oldestActive.UpdatedAt.Time.After(ruleset.UpdatedAt.Time) {
+				if oldestActive == nil || oldestActive.UpdatedAt.After(ruleset.UpdatedAt.Time) {
 					oldestActive = ruleset
 				}
 			}
@@ -221,7 +222,7 @@ func (ghc *GitHubConnection) getOldestActiveRule(ctx context.Context, rules []*g
 			return nil, err
 		}
 		if ruleset.Enforcement == "active" {
-			if oldestActive == nil || oldestActive.UpdatedAt.Time.After(ruleset.UpdatedAt.Time) {
+			if oldestActive == nil || oldestActive.UpdatedAt.After(ruleset.UpdatedAt.Time) {
 				oldestActive = ruleset
 			}
 		}
@@ -242,7 +243,8 @@ func (ghc *GitHubConnection) GetBranchControls(ctx context.Context, commit, ref 
 		CommitPushTime: activity.Timestamp,
 		ActivityType:   activity.ActivityType,
 		ActorLogin:     activity.Actor.Login,
-		Controls:       slsa.Controls{}}
+		Controls:       slsa.Controls{},
+	}
 
 	branch := GetBranchFromRef(ref)
 	if branch == "" {
@@ -289,7 +291,8 @@ func (ghc *GitHubConnection) GetBranchControls(ctx context.Context, commit, ref 
 func (ghc *GitHubConnection) GetTagControls(ctx context.Context, commit, ref string) (*GhControlStatus, error) {
 	controlStatus := GhControlStatus{
 		CommitPushTime: time.Now(),
-		Controls:       slsa.Controls{}}
+		Controls:       slsa.Controls{},
+	}
 
 	allRulesets, _, err := ghc.Client().Repositories.GetAllRulesets(ctx, ghc.Owner(), ghc.Repo(), true)
 	if err != nil {

--- a/sourcetool/pkg/ghcontrol/checklevel_test.go
+++ b/sourcetool/pkg/ghcontrol/checklevel_test.go
@@ -295,7 +295,7 @@ func TestGetBranchControlsRequiredChecks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(string(tt.name), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			ghc := newTestGhConnection("owner", "repo", "branch_name",
 				newRepoRulesets(123, github.RulesetTargetTag,
 					github.RulesetEnforcementActive, priorTime, rulesForRequiredChecks()),

--- a/sourcetool/pkg/ghcontrol/checklevel_test.go
+++ b/sourcetool/pkg/ghcontrol/checklevel_test.go
@@ -1,7 +1,6 @@
 package ghcontrol
 
 import (
-	"context"
 	"encoding/json"
 	"log"
 	"slices"
@@ -10,11 +9,14 @@ import (
 
 	"github.com/google/go-github/v69/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
+
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
-var curTime = time.Unix(1678886400, 0) // March 15, 2023 00:00:00 UTC
-var priorTime = curTime.Add(-time.Hour)
+var (
+	curTime   = time.Unix(1678886400, 0) // March 15, 2023 00:00:00 UTC
+	priorTime = curTime.Add(-time.Hour)
+)
 
 // branchOrTagName could also be ~ALL or ~DEFAULT?
 func conditionsForRuleset(branchOrTagName string) *github.RepositoryRulesetConditions {
@@ -26,7 +28,8 @@ func conditionsForRuleset(branchOrTagName string) *github.RepositoryRulesetCondi
 }
 
 func newRepoRulesets(id int64, target github.RulesetTarget, enforcement github.RulesetEnforcement,
-	updatedAt time.Time, rules *github.RepositoryRulesetRules) *github.RepositoryRuleset {
+	updatedAt time.Time, rules *github.RepositoryRulesetRules,
+) *github.RepositoryRuleset {
 	return &github.RepositoryRuleset{
 		ID:          github.Ptr(id),
 		Target:      github.Ptr(target),
@@ -254,8 +257,7 @@ func TestBuiltinBranchControls(t *testing.T) {
 					github.RulesetEnforcementActive, priorTime, tt.rulesetRules),
 				activityForBranch("abc123", "refs/heads/branch_name"), &tt.branchRules)
 
-			controlStatus, err := ghc.GetBranchControls(context.Background(), "abc123", "refs/heads/branch_name")
-
+			controlStatus, err := ghc.GetBranchControls(t.Context(), "abc123", "refs/heads/branch_name")
 			if err != nil {
 				t.Fatalf("Error getting branch controls: %v", err)
 			}
@@ -294,14 +296,12 @@ func TestGetBranchControlsRequiredChecks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.name), func(t *testing.T) {
-
 			ghc := newTestGhConnection("owner", "repo", "branch_name",
 				newRepoRulesets(123, github.RulesetTargetTag,
 					github.RulesetEnforcementActive, priorTime, rulesForRequiredChecks()),
 				activityForBranch("abc123", "refs/heads/branch_name"), &tt.checks)
 
-			controlStatus, err := ghc.GetBranchControls(context.Background(), "abc123", "refs/heads/branch_name")
-
+			controlStatus, err := ghc.GetBranchControls(t.Context(), "abc123", "refs/heads/branch_name")
 			if err != nil {
 				t.Fatalf("Error getting branch controls: %v", err)
 			}

--- a/sourcetool/pkg/ghcontrol/connection.go
+++ b/sourcetool/pkg/ghcontrol/connection.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-github/v69/github"
 )
 
-const tokenEnvVar = "GITHUB_TOKEN"
+const tokenEnvVar = "GITHUB_TOKEN" //nolint:gosec // These are not credentials
 
 // Manages a connection to a GitHub repository.
 type GitHubConnection struct {

--- a/sourcetool/pkg/ghcontrol/git_types.go
+++ b/sourcetool/pkg/ghcontrol/git_types.go
@@ -8,8 +8,10 @@ import (
 )
 
 // Matches any reference type.
-const AnyReference = "*"
-const GitHubActionsIntegrationId = int64(15368)
+const (
+	AnyReference               = "*"
+	GitHubActionsIntegrationId = int64(15368)
+)
 
 func BranchToFullRef(branch string) string {
 	return fmt.Sprintf("refs/heads/%s", branch)

--- a/sourcetool/pkg/ghcontrol/notes_test.go
+++ b/sourcetool/pkg/ghcontrol/notes_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 func TestGetNotesForCommit(t *testing.T) {
+	t.Parallel()
 	if tk := os.Getenv(tokenEnvVar); tk == "" {
 		t.Log("Skipping API test as no token is set")
 		t.Skip()
 	}
-	t.Parallel()
+
 	for _, tc := range []struct {
 		name        string
 		owner       string

--- a/sourcetool/pkg/ghcontrol/notes_test.go
+++ b/sourcetool/pkg/ghcontrol/notes_test.go
@@ -1,7 +1,6 @@
 package ghcontrol
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestGetNotesForCommit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ghc := NewGhConnection(tc.owner, tc.repo, "main")
-			notes, err := ghc.GetNotesForCommit(context.Background(), tc.commit)
+			notes, err := ghc.GetNotesForCommit(t.Context(), tc.commit)
 			if tc.mustErr {
 				require.Error(t, err)
 				return

--- a/sourcetool/pkg/slsa/slsa_types.go
+++ b/sourcetool/pkg/slsa/slsa_types.go
@@ -62,8 +62,8 @@ func (controls *Controls) AddControl(newControls ...*Control) {
 }
 
 // Gets the control with the corresponding name, returns nil if not found.
-func (controls Controls) GetControl(name ControlName) *Control {
-	for _, control := range controls {
+func (controls *Controls) GetControl(name ControlName) *Control {
+	for _, control := range *controls {
 		if control.Name == name {
 			return &control
 		}
@@ -71,7 +71,7 @@ func (controls Controls) GetControl(name ControlName) *Control {
 	return nil
 }
 
-func (controls Controls) AreControlsAvailable(names []ControlName) bool {
+func (controls *Controls) AreControlsAvailable(names []ControlName) bool {
 	for _, name := range names {
 		if controls.GetControl(name) == nil {
 			return false
@@ -81,10 +81,10 @@ func (controls Controls) AreControlsAvailable(names []ControlName) bool {
 }
 
 // Returns the names of the controls.
-func (controls Controls) Names() []ControlName {
-	names := make([]ControlName, len(controls))
-	for i := range controls {
-		names[i] = controls[i].Name
+func (controls *Controls) Names() []ControlName {
+	names := make([]ControlName, len(*controls))
+	for i := range *controls {
+		names[i] = (*controls)[i].Name
 	}
 	return names
 }

--- a/sourcetool/pkg/slsa/slsa_types.go
+++ b/sourcetool/pkg/slsa/slsa_types.go
@@ -5,8 +5,10 @@ import (
 	"time"
 )
 
-type ControlName string
-type SlsaSourceLevel ControlName
+type (
+	ControlName     string
+	SlsaSourceLevel ControlName
+)
 
 const (
 	SlsaSourceLevel1         SlsaSourceLevel = "SLSA_SOURCE_LEVEL_1"
@@ -28,7 +30,8 @@ func IsSlsaSourceLevel(control ControlName) bool {
 			ControlName(SlsaSourceLevel1),
 			ControlName(SlsaSourceLevel2),
 			ControlName(SlsaSourceLevel3),
-			ControlName(SlsaSourceLevel4)},
+			ControlName(SlsaSourceLevel4),
+		},
 		control)
 }
 

--- a/sourcetool/pkg/testsupport/mockverify.go
+++ b/sourcetool/pkg/testsupport/mockverify.go
@@ -8,8 +8,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-type MockVerifier struct {
-}
+type MockVerifier struct{}
 
 func NewMockVerifier() *MockVerifier {
 	return &MockVerifier{}


### PR DESCRIPTION
This is probably the last big one, this PR fixes all linter issues in the code. In addition to the golangci-lint config, this PR adds a presubmit to run the linter on pull requests.

There are no functional changes beyond some small optimizations, including normalizing the interfaces of some methods to unify them using pointers. The tests caught two breaking issues, which are now fixed, hopefully, those were all of them.


Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>