### PR TITLE
chore: Update CLI to use errors and Cobra's RunE

### DIFF
--- a/sourcetool/cmd/audit.go
+++ b/sourcetool/cmd/audit.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 
@@ -87,11 +86,8 @@ Future:
 * Check the provenance to validate the verifiedLevels in the VSA match expectations
   (i.e. that the VSA was issued correctly)
 `,
-		Run: func(cmd *cobra.Command, args []string) {
-			err := doAudit(auditArgs)
-			if err != nil {
-				log.Fatal(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return doAudit(auditArgs)
 		},
 	}
 )

--- a/sourcetool/cmd/checklevelprov.go
+++ b/sourcetool/cmd/checklevelprov.go
@@ -39,10 +39,8 @@ var (
 	checklevelprovCmd = &cobra.Command{
 		Use:   "checklevelprov",
 		Short: "Checks the given commit against policy using & creating provenance",
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doCheckLevelProv(checkLevelProvArgs); err != nil {
-				log.Fatal(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return doCheckLevelProv(checkLevelProvArgs)
 		},
 	}
 )

--- a/sourcetool/cmd/checktag.go
+++ b/sourcetool/cmd/checktag.go
@@ -34,10 +34,8 @@ var (
 	checktagCmd = &cobra.Command{
 		Use:   "checktag",
 		Short: "Checks to see if the tag operation should be allowed and issues a VSA",
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doCheckTag(checkTagArgs); err != nil {
-				log.Fatal(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return doCheckTag(checkTagArgs)
 		},
 	}
 )

--- a/sourcetool/cmd/createpolicy.go
+++ b/sourcetool/cmd/createpolicy.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 
@@ -28,20 +27,21 @@ var (
 		Long: `Creates a SLSA source policy in a local copy of slsa-source-poc.
 
 		The created policy should then be sent as a PR to slsa-framework/slsa-source-poc.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			doCreatePolicy(createPolicyArgs.policyRepoPath, createPolicyArgs.owner, createPolicyArgs.repo, createPolicyArgs.branch)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return doCreatePolicy(createPolicyArgs.policyRepoPath, createPolicyArgs.owner, createPolicyArgs.repo, createPolicyArgs.branch)
 		},
 	}
 )
 
-func doCreatePolicy(policyRepoPath, owner, repo, branch string) {
+func doCreatePolicy(policyRepoPath, owner, repo, branch string) error {
 	ghconnection := ghcontrol.NewGhConnection(owner, repo, ghcontrol.BranchToFullRef(branch)).WithAuthToken(githubToken)
 	ctx := context.Background()
 	outpath, err := policy.CreateLocalPolicy(ctx, ghconnection, policyRepoPath)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	fmt.Printf("Wrote policy to %s\n", outpath)
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
This improves the control flow. When RunE is used, if the error is non- nil, the error will be shown to the user.

---

I know it's just a PoC, but... 