### PR TITLE
Add status subcommand

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -37,6 +37,7 @@ github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSY
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/CycloneDX/cyclonedx-go v0.9.1/go.mod h1:NE/EWvzELOFlG6+ljX/QeMlVt9VKcTwu8u0ccsACEsw=
+github.com/CycloneDX/cyclonedx-go v0.9.2 h1:688QHn2X/5nRezKe2ueIVCt+NRqf7fl3AVQk+vaFcIo=
 github.com/CycloneDX/cyclonedx-go v0.9.2/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0/go.mod h1:obipzmGjfSjam60XLwGfqUkJsfiheAl+TUjG+4yzyPM=
@@ -80,6 +81,7 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beevik/ntp v1.4.3/go.mod h1:Unr8Zg+2dRn7d8bHFuehIMSvvUYssHMxW3Q5Nx4RW5Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bufbuild/protocompile v0.10.0/go.mod h1:G9qQIQo0xZ6Uyj6CMNz0saGmx2so+KONo8/KrELABiY=
@@ -90,6 +92,7 @@ github.com/buildkite/interpolate v0.1.3/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DX
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/carabiner-dev/ampel v0.0.0-20250209210344-7b306497c927/go.mod h1:KJBPGPxyllTdgWoMW/lD3KBa/KAvVznZXzgUQUyPFxs=
+github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193 h1:wD6nGN7gq5IQJ4qFF0V4Jpu8B2FM+9ZnwlUqN5scWxk=
 github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193/go.mod h1:sQEeCRjbikSoqB1+VmZmWK2R0u2NdauEXDab+VlS8pQ=
 github.com/carabiner-dev/github v0.0.0-20250210222226-442fdacc1d16 h1:6ESg7ESScHJp/e4zHO1a1y6XDAJYTcK9N06mqbqBvUg=
 github.com/carabiner-dev/github v0.0.0-20250210222226-442fdacc1d16/go.mod h1:hAfka+26SmZJoTfpWUnIeQUVKFYcT45RUPXqBsqxWpU=
@@ -97,8 +100,11 @@ github.com/carabiner-dev/github v0.2.2/go.mod h1:J7VqMAUewwRQH6r6HMDmVNf39f/z7H5
 github.com/carabiner-dev/hasher v0.1.0/go.mod h1:+X5f8ts4Q/ubkmsWQGzCQwPxtJx39AoqoT/IlDR7M9Q=
 github.com/carabiner-dev/hasher v0.2.2/go.mod h1:bM7reKZ5gGEY4Bbcd3Lr2KhrtqNkEhJOmQ4ptGasnFY=
 github.com/carabiner-dev/jsonl v0.2.0/go.mod h1:H0ac1z6a6AEvRx1+laZrztAdGoYuB/CVlGXK5nHHQyI=
+github.com/carabiner-dev/openeox v0.0.0-20250430212020-e3a5beb42ddd h1:WEQbh3d2h0x2BIwrIQWeBqlGugjVfIgXSKX/4mNxkjA=
 github.com/carabiner-dev/openeox v0.0.0-20250430212020-e3a5beb42ddd/go.mod h1:40KVT1ee6L8VoWT44RvAQ0AtG91MFr5/zBzTmNiXQWY=
+github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
+github.com/carabiner-dev/vcslocator v0.2.2 h1:UXhuMUxtDiwGzfCxvpNJXRyqUY8qZl0+Ug3TjJluS4s=
 github.com/carabiner-dev/vcslocator v0.2.2/go.mod h1:/67gubbzxtg25MIg/eRlmBkHExFDqyVZ2Dj0VJatHwE=
 github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e/go.mod h1:V284PjgVwSk4ETmz84rpu9ehpGg7swlIH8npP9k2bGw=
 github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8/go.mod h1:AZIh1CCnMrcVm6afFf96PBvE2MRpWFco91z8ObJtgDY=
@@ -275,6 +281,7 @@ github.com/nats-io/nats.go v1.34.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF
 github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -293,8 +300,10 @@ github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9
 github.com/open-policy-agent/opa v0.68.0/go.mod h1:5E5SvaPwTpwt2WM177I9Z3eT7qUpmOGjk1ZdHs+TZ4w=
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/openvex/go-vex v0.2.5 h1:41utdp2rHgAGCsG+UbjmfMG5CWQxs15nGqir1eRgSrQ=
 github.com/openvex/go-vex v0.2.5/go.mod h1:j+oadBxSUELkrKh4NfNb+BPo77U3q7gdKME88IO/0Wo=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
+github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
 github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
@@ -307,6 +316,7 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
 github.com/prometheus/prometheus v0.51.0/go.mod h1:yv4MwOn3yHMQ6MZGHPg/U7Fcyqf+rxqiZfSur6myVtc=
 github.com/protobom/protobom v0.5.0/go.mod h1:HL47tggz7SXYXgNm3WjQQrWB6iOirYnrATsXAEyTUkI=
+github.com/protobom/protobom v0.5.2 h1:GQacWLer4tDskyjQpqbglXkT3ZlNy7AJCw/S2XZkVS8=
 github.com/protobom/protobom v0.5.2/go.mod h1:io5yUKGWBqGa2sx1n7aVPg+tG13Hun9oMz4Y+EjNjjc=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -323,6 +333,7 @@ github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWR
 github.com/sigstore/cosign/v2 v2.4.1/go.mod h1:GvzjBeUKigI+XYnsoVQDmMAsMMc6engxztRSuxE+x9I=
 github.com/sigstore/fulcio v1.6.3/go.mod h1:5SDgLn7BOUVLKe1DwOEX3wkWFu5qEmhUlWm+SFf0GH8=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/spdx/tools-golang v0.5.5 h1:61c0KLfAcNqAjlg6UNMdkwpMernhw3zVRwDZ2x9XOmk=
 github.com/spdx/tools-golang v0.5.5/go.mod h1:MVIsXx8ZZzaRWNQpUDhC4Dud34edUYJYecciXgrw5vE=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spiffe/go-spiffe/v2 v2.1.3/go.mod h1:eVDqm9xFvyqao6C+eQensb9ZPkyNEeaUbqbBpOhBnNk=
@@ -485,6 +496,7 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/release-sdk v0.12.1/go.mod h1:nnB4tt1g0VXMUCIYzDzPVqNI896OQrWipE6WbyZ6FSk=
+sigs.k8s.io/release-sdk v0.12.2 h1:ncuHwUu8VWcZVVrNkjoUR8xGo6ibHg+AM6uMMD+IwuQ=
 sigs.k8s.io/release-sdk v0.12.2/go.mod h1:tlJgWPJLeRbWOvcyq1XrCZmLe8Yfn3H5U/LNtmBa0Nc=
 sigs.k8s.io/release-utils v0.8.5/go.mod h1:qsm5bdxdgoHkD8HsXpgme2/c3mdsNaiV53Sz2HmKeJA=
 sigs.k8s.io/release-utils v0.9.0/go.mod h1:xZoCJyajMJ0wtgGXWuznbC1r9dw7iJzMp/+dCkf1UGw=

--- a/sourcetool/cmd/root.go
+++ b/sourcetool/cmd/root.go
@@ -4,6 +4,7 @@ Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -48,6 +49,7 @@ func getVerifier() attest.Verifier {
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
+		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -60,4 +62,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&githubToken, "github_token", "", "the github token to use for auth")
 	rootCmd.PersistentFlags().StringVar(&expectedIssuer, "expected_issuer", "", "The expected issuer of attestations.")
 	rootCmd.PersistentFlags().StringVar(&expectedSan, "expected_san", "", "The expect san of attestations.")
+
+	addStatus(rootCmd)
 }

--- a/sourcetool/cmd/status.go
+++ b/sourcetool/cmd/status.go
@@ -173,7 +173,7 @@ SLSA journey.
 			fmt.Println(w(title))
 			fmt.Println(strings.Repeat("=", len(title)))
 
-			for _, c := range slsa.ControlNames {
+			for _, c := range slsa.AllLevelControls {
 				fmt.Printf("%-35s  ", c)
 				if slices.Contains(activeControls.Controls.Names(), c) {
 					fmt.Println("✅")

--- a/sourcetool/cmd/status.go
+++ b/sourcetool/cmd/status.go
@@ -142,10 +142,7 @@ SLSA journey.
 				return fmt.Errorf("checking status: %w", err)
 			}
 
-			activeLabels := []string{}
-			for _, c := range activeControls.Controls {
-				activeLabels = append(activeLabels, string(c.Name))
-			}
+			activeLabels := activeControls.Controls.Names()
 
 			// We need to manually check for PROVENANCE_AVAILABLE
 			attestor := attest.NewProvenanceAttestor(
@@ -174,7 +171,7 @@ SLSA journey.
 				slsa.SlsaSourceLevel1, slsa.SlsaSourceLevel2,
 				slsa.SlsaSourceLevel3, slsa.SlsaSourceLevel4,
 			} {
-				if met, _ := level.MetByControls(slsa.StringsToControlNames(activeLabels)); met {
+				if met, _ := level.MetByControls(activeLabels); met {
 					toplevel = level
 				}
 			}
@@ -186,7 +183,7 @@ SLSA journey.
 
 			for _, c := range slsa.ControlNames {
 				fmt.Printf("%-35s  ", c)
-				if slices.Contains(activeLabels, string(c)) {
+				if slices.Contains(activeLabels, c) {
 					fmt.Println("✅")
 				} else {
 					fmt.Println("🚫")

--- a/sourcetool/cmd/status.go
+++ b/sourcetool/cmd/status.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
+)
+
+var w = color.New(color.FgHiWhite, color.BgBlack).SprintFunc()
+
+type repoOptions struct {
+	owner      string
+	repository string
+}
+
+func (ro *repoOptions) Validate() error {
+	errs := []error{}
+	if ro.owner == "" {
+		errs = append(errs, errors.New("repository owner not set"))
+	}
+	if ro.repository == "" {
+		errs = append(errs, errors.New(""))
+	}
+	return errors.Join(errs...)
+}
+
+// AddFlags adds the subcommands flags
+func (ro *repoOptions) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(
+		&ro.repository, "repository", "", "name of the repository",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&ro.owner, "owner", "", "user or oganization that owns the repo",
+	)
+}
+
+func (bo *branchOptions) Validate() error {
+	errs := []error{}
+	errs = append(errs, bo.repoOptions.Validate())
+
+	if bo.branch == "" {
+		return errors.New("branch not set")
+	}
+	return errors.Join(errs...)
+}
+
+// AddFlags adds the subcommands flags
+func (bo *branchOptions) AddFlags(cmd *cobra.Command) {
+	bo.repoOptions.AddFlags(cmd)
+
+	cmd.PersistentFlags().StringVar(
+		&bo.branch, "branch", "", "name of the branch",
+	)
+}
+
+type branchOptions struct {
+	repoOptions
+	branch string
+}
+
+// statusOptions
+type statusOptions struct {
+	branchOptions
+	commit string
+}
+
+// Validate checks the options
+func (so *statusOptions) Validate() error {
+	errs := []error{}
+	errs = append(errs, so.branchOptions.Validate())
+	if so.commit == "" {
+		errs = append(errs, errors.New("commit must be set"))
+	}
+	return errors.Join(errs...)
+}
+
+// AddFlags adds the subcommands flags
+func (so *statusOptions) AddFlags(cmd *cobra.Command) {
+	so.branchOptions.AddFlags(cmd)
+	cmd.PersistentFlags().StringVar(
+		&so.commit, "commit", "", "commit to check",
+	)
+}
+
+// TODO(puerco): Most of the logic in this subcommand (except maybe the output)
+// will be moved to a sourcetool obkect in the future to consolidate it into
+// a reusable library.
+func addStatus(parentCmd *cobra.Command) {
+	opts := &statusOptions{}
+	statusCmd := &cobra.Command{
+		Short:         "check the status of a branch",
+		Use:           "status",
+		SilenceUsage:  false,
+		SilenceErrors: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate the options
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			cmd.SilenceUsage = true
+
+			ctx := context.Background()
+			ghc := ghcontrol.NewGhConnection(opts.owner, opts.repository, opts.branch)
+
+			// Get the active controls
+			activeControls, err := ghc.GetBranchControls(ctx, opts.commit, ghcontrol.BranchToFullRef(opts.branch))
+			if err != nil {
+				return fmt.Errorf("checking status: %w", err)
+			}
+
+			activeLabels := []string{}
+			for _, c := range activeControls.Controls {
+				activeLabels = append(activeLabels, string(c.Name))
+			}
+
+			// We need to manually check for PROVENANCE_AVAILABLE
+			attestor := attest.NewProvenanceAttestor(
+				ghcontrol.NewGhConnection(opts.owner, opts.repository, opts.branch),
+				attest.GetDefaultVerifier(),
+			)
+
+			// Fetch the attestation, if found then add the control
+			attestation, _, err := attestor.GetProvenance(ctx, opts.commit, "refs/heads/"+opts.branch)
+			if err != nil {
+				return fmt.Errorf("attempting to read provenance from commit: %w", err)
+			}
+			if attestation != nil {
+				activeLabels = append(activeLabels, "PROVENANCE_AVAILABLE")
+			}
+
+			// Check if there is a policy:
+			pcy, err := policy.NewPolicyEvaluator().GetRepositoryPolicy(
+				ctx, fmt.Sprintf("git+https://github.com/%s/%s@%s", opts.owner, opts.repository, opts.branch),
+			)
+			if err != nil {
+				return fmt.Errorf("checking if the repository has a policy %w", err)
+			}
+
+			// Compute the maximum level possible:
+			var toplevel slsa.SlsaSourceLevel
+			for _, level := range []slsa.SlsaSourceLevel{
+				slsa.SlsaSourceLevel1, slsa.SlsaSourceLevel2,
+				slsa.SlsaSourceLevel3, slsa.SlsaSourceLevel4,
+			} {
+				if met, _ := level.MetByControls(slsa.StringsToControlNames(activeLabels)); met {
+					toplevel = level
+				}
+			}
+
+			title := fmt.Sprintf("SLSA Source Status for %s/%s", opts.owner, opts.repository)
+			fmt.Printf("")
+			fmt.Println(w(title))
+			fmt.Println(strings.Repeat("=", len(title)))
+
+			for _, c := range slsa.ControlNames {
+				fmt.Printf("%-35s  ", c)
+				if slices.Contains(activeLabels, string(c)) {
+					fmt.Println("✅")
+				} else {
+					fmt.Println("🚫")
+				}
+			}
+
+			fmt.Println("")
+			fmt.Printf("%-35s  ", "Repo policy found:")
+			if pcy == nil {
+				fmt.Println("🚫")
+			} else {
+				fmt.Println("✅")
+			}
+			fmt.Println("")
+
+			fmt.Println(w("Current SLSA Source level: " + toplevel))
+			fmt.Println("")
+
+			return nil
+		},
+	}
+	opts.AddFlags(statusCmd)
+	parentCmd.AddCommand(statusCmd)
+}

--- a/sourcetool/cmd/status.go
+++ b/sourcetool/cmd/status.go
@@ -102,7 +102,16 @@ func (so *statusOptions) AddFlags(cmd *cobra.Command) {
 func addStatus(parentCmd *cobra.Command) {
 	opts := &statusOptions{}
 	statusCmd := &cobra.Command{
-		Short:         "check the status of a branch",
+		Short: "Check the SLSA Source status of a repo/branch",
+		Long: `
+sourcetool status: Check the SLSA Source status of a repo/branch
+
+The status subcommand reads the current controls enabled for a branch
+and reports the SLSA source level that the repository can claim. This
+command is intended to help maintainers implementing SLSA controls
+understand the next steps to secure their repos and progress in their
+SLSA journey. 
+`,
 		Use:           "status",
 		SilenceUsage:  false,
 		SilenceErrors: true,

--- a/sourcetool/go.mod
+++ b/sourcetool/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/carabiner-dev/bnd v0.2.0
+	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-github/v69 v69.2.0
 	github.com/in-toto/attestation v1.1.2-0.20250128181946-c0b4d86cf712
@@ -30,7 +31,6 @@ require (
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -67,6 +67,8 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20240620165639-de9c06129bec // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/sourcetool/go.sum
+++ b/sourcetool/go.sum
@@ -272,6 +272,7 @@ github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/migueleliasweb/go-github-mock v1.3.0 h1:2sVP9JEMB2ubQw1IKto3/fzF51oFC6eVWOOFDgQoq88=
@@ -448,6 +449,8 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/sourcetool/pkg/ghcontrol/checklevel_test.go
+++ b/sourcetool/pkg/ghcontrol/checklevel_test.go
@@ -265,8 +265,7 @@ func TestBuiltinBranchControls(t *testing.T) {
 			control := controlStatus.Controls.GetControl(tt.expectedControl)
 			if control == nil {
 				t.Fatalf("expected controls to contain %v, got %+v", tt.expectedControl, controlStatus.Controls)
-			}
-			if !control.Since.Equal(priorTime) {
+			} else if !control.Since.Equal(priorTime) {
 				t.Fatalf("expected control.Since %v, got %v", priorTime, control.Since)
 			}
 		})

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -217,7 +217,7 @@ func CreateLocalPolicy(ctx context.Context, ghconnection *ghcontrol.GitHubConnec
 	// Unless there is previous provenance metadata, then we can compute
 	// a higher level
 	if provPred != nil {
-		eligibleLevel = computeEligibleSlsaLevel(provPred.Controls)
+		eligibleLevel = ComputeEligibleSlsaLevel(provPred.Controls)
 		eligibleSince, err = computeEligibleSince(provPred.Controls, eligibleLevel)
 		if err != nil {
 			return "", fmt.Errorf("could not compute eligible since: %w", err)
@@ -258,7 +258,7 @@ func computeEligibleForLevel(controls slsa.Controls, level slsa.SlsaSourceLevel)
 
 // Computes the eligible SLSA level, and when they started being eligible for it,
 // if only they had a policy.  Also returns a rationale for why it's eligible for this level.
-func computeEligibleSlsaLevel(controls slsa.Controls) slsa.SlsaSourceLevel {
+func ComputeEligibleSlsaLevel(controls slsa.Controls) slsa.SlsaSourceLevel {
 	// Go from highest to lowest.
 	for _, level := range []slsa.SlsaSourceLevel{
 		slsa.SlsaSourceLevel4, slsa.SlsaSourceLevel3, slsa.SlsaSourceLevel2,
@@ -300,7 +300,7 @@ func computeEligibleSince(controls slsa.Controls, level slsa.SlsaSourceLevel) (*
 type computePolicyResult func(*ProtectedBranch, *ProtectedTag, slsa.Controls) ([]slsa.ControlName, error)
 
 func computeSlsaLevel(branchPolicy *ProtectedBranch, _ *ProtectedTag, controls slsa.Controls) ([]slsa.ControlName, error) {
-	eligibleLevel := computeEligibleSlsaLevel(controls)
+	eligibleLevel := ComputeEligibleSlsaLevel(controls)
 
 	if !slsa.IsLevelHigherOrEqualTo(eligibleLevel, branchPolicy.TargetSlsaSourceLevel) {
 		return []slsa.ControlName{}, fmt.Errorf(

--- a/sourcetool/pkg/policy/policy.go
+++ b/sourcetool/pkg/policy/policy.go
@@ -130,7 +130,10 @@ func getLocalPolicy(path string) (*RepoPolicy, string, error) {
 	return &p, path, nil
 }
 
-func (pe PolicyEvaluator) getPolicy(ctx context.Context, ghconnection *ghcontrol.GitHubConnection) (policy *RepoPolicy, path string, err error) {
+// GetPolicy fetches the policy for a repository from the SLSA source repo.
+// For debugging purposes, if UseLocalPolicy is defined, then the policy will
+// be read from a local file.
+func (pe PolicyEvaluator) GetPolicy(ctx context.Context, ghconnection *ghcontrol.GitHubConnection) (policy *RepoPolicy, path string, err error) {
 	if pe.UseLocalPolicy == "" {
 		policy, path, err = getRemotePolicy(ctx, ghconnection)
 	} else {
@@ -458,7 +461,7 @@ func NewPolicyEvaluator() *PolicyEvaluator {
 func (pe PolicyEvaluator) EvaluateControl(ctx context.Context, ghconnection *ghcontrol.GitHubConnection, controlStatus *ghcontrol.GhControlStatus) (slsa.SourceVerifiedLevels, string, error) {
 	// We want to check to ensure the repo hasn't enabled/disabled the rules since
 	// setting the 'since' field in their policy.
-	rp, policyPath, err := pe.getPolicy(ctx, ghconnection)
+	rp, policyPath, err := pe.GetPolicy(ctx, ghconnection)
 	if err != nil || rp == nil {
 		return slsa.SourceVerifiedLevels{}, "", err
 	}
@@ -484,7 +487,7 @@ func (pe PolicyEvaluator) EvaluateControl(ctx context.Context, ghconnection *ghc
 
 // Evaluates the provenance against the policy and returns the resulting source level and policy path
 func (pe PolicyEvaluator) EvaluateSourceProv(ctx context.Context, ghconnection *ghcontrol.GitHubConnection, prov *spb.Statement) (slsa.SourceVerifiedLevels, string, error) {
-	rp, policyPath, err := pe.getPolicy(ctx, ghconnection)
+	rp, policyPath, err := pe.GetPolicy(ctx, ghconnection)
 	if err != nil || rp == nil {
 		return slsa.SourceVerifiedLevels{}, "", err
 	}
@@ -512,7 +515,7 @@ func (pe PolicyEvaluator) EvaluateSourceProv(ctx context.Context, ghconnection *
 
 // Evaluates the provenance against the policy and returns the resulting source level and policy path
 func (pe PolicyEvaluator) EvaluateTagProv(ctx context.Context, ghconnection *ghcontrol.GitHubConnection, prov *spb.Statement) (slsa.SourceVerifiedLevels, string, error) {
-	rp, policyPath, err := pe.getPolicy(ctx, ghconnection)
+	rp, policyPath, err := pe.GetPolicy(ctx, ghconnection)
 	if err != nil {
 		return slsa.SourceVerifiedLevels{}, "", err
 	}

--- a/sourcetool/pkg/policy/policy_test.go
+++ b/sourcetool/pkg/policy/policy_test.go
@@ -235,7 +235,7 @@ func TestEvaluateSourceProv_Failure(t *testing.T) {
 			policyContent:         "not valid policy json",
 			provenanceStatement:   createStatementForTest(t, validProvPredicateL3Controls, attest.SourceProvPredicateType),
 			ghConnBranch:          "main",
-			expectedErrorContains: "invalid character 'o' in literal null (expecting 'u')", // Error from getPolicy via getLocalPolicy
+			expectedErrorContains: "invalid character 'o' in literal null (expecting 'u')", // Error from GetPolicy via getLocalPolicy
 		},
 		{
 			name:                  "Non-existent Policy File -> Error",
@@ -1389,22 +1389,22 @@ func TestComputeEligibleSince(t *testing.T) {
 }
 
 func assertPolicyResultEquals(t *testing.T, ctx context.Context, ghConn *ghcontrol.GitHubConnection, pe *PolicyEvaluator, expectedPolicy *RepoPolicy, expectedBranchPolicy *ProtectedBranch, expectedPath string) {
-	rp, gotPath, err := pe.getPolicy(ctx, ghConn)
+	rp, gotPath, err := pe.GetPolicy(ctx, ghConn)
 	if err != nil {
-		t.Fatalf("getPolicy() error = %v, want nil", err)
+		t.Fatalf("GetPolicy() error = %v, want nil", err)
 	}
 	if gotPath != expectedPath {
-		t.Errorf("getPolicy() gotPath = %q, want %q (temp file path)", gotPath, expectedPath)
+		t.Errorf("GetPolicy() gotPath = %q, want %q (temp file path)", gotPath, expectedPath)
 	}
 	if expectedPolicy == nil {
 		if rp != nil {
-			t.Fatalf("getPolicy() expectedPolicy == nil but got non-nil policy %+v", rp)
+			t.Fatalf("GetPolicy() expectedPolicy == nil but got non-nil policy %+v", rp)
 		}
 		return // quite while we're ahead
 	}
 
 	if rp == nil {
-		t.Fatalf("getPolicy() rp is nil but expectedPolicy is not")
+		t.Fatalf("GetPolicy() rp is nil but expectedPolicy is not")
 	}
 
 	// TODO: check the rest of the contents of expectedPolicy?
@@ -1413,7 +1413,7 @@ func assertPolicyResultEquals(t *testing.T, ctx context.Context, ghConn *ghcontr
 
 	if expectedBranchPolicy == nil {
 		if gotPb != nil {
-			t.Fatalf("getPolicy() expectedBranchPolicy == nil but got non-nil branch policy %+v", rp)
+			t.Fatalf("GetPolicy() expectedBranchPolicy == nil but got non-nil branch policy %+v", rp)
 		}
 		return
 	}
@@ -1515,16 +1515,16 @@ func TestGetPolicy_Local_ErrorCases(t *testing.T) {
 				pe.UseLocalPolicy = tt.useLocalPolicyPath // For non-existent file
 			}
 
-			gotRp, gotPath, err := pe.getPolicy(ctx, ghConn)
+			gotRp, gotPath, err := pe.GetPolicy(ctx, ghConn)
 
 			if err == nil {
-				t.Errorf("getPolicy() error = nil, want non-nil error")
+				t.Errorf("GetPolicy() error = nil, want non-nil error")
 			}
 			if gotRp != nil {
-				t.Errorf("getPolicy() gotRp = %v, want nil", gotRp)
+				t.Errorf("GetPolicy() gotRp = %v, want nil", gotRp)
 			}
 			if gotPath != "" {
-				t.Errorf("getPolicy() gotPath = %q, want \"\"", gotPath)
+				t.Errorf("GetPolicy() gotPath = %q, want \"\"", gotPath)
 			}
 		})
 	}
@@ -1669,7 +1669,7 @@ func TestGetPolicy_Remote_ServerError(t *testing.T) {
 	pe := PolicyEvaluator{UseLocalPolicy: ""}
 	// ghConn is now returned by setupMockGitHubTestEnv
 
-	gotPolicy, gotPath, err := pe.getPolicy(ctx, ghConn)
+	gotPolicy, gotPath, err := pe.GetPolicy(ctx, ghConn)
 	if err == nil {
 		t.Errorf("Expected an error for server-side issues, got nil")
 	}
@@ -1735,7 +1735,7 @@ func TestGetPolicy_Remote_MalformedJSON(t *testing.T) {
 
 			pe := PolicyEvaluator{UseLocalPolicy: ""}
 
-			gotPolicy, gotPath, err := pe.getPolicy(ctx, ghConn)
+			gotPolicy, gotPath, err := pe.GetPolicy(ctx, ghConn)
 			if err == nil {
 				t.Errorf("Expected an error for malformed JSON, got nil")
 			}

--- a/sourcetool/pkg/policy/policy_test.go
+++ b/sourcetool/pkg/policy/policy_test.go
@@ -719,7 +719,7 @@ func TestComputeEligibleSlsaLevel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			level := computeEligibleSlsaLevel(tt.controls)
+			level := ComputeEligibleSlsaLevel(tt.controls)
 			if level != tt.expectedLevel {
 				t.Errorf("computeEligibleSlsaLevel() level = %v, want %v", level, tt.expectedLevel)
 			}

--- a/sourcetool/pkg/slsa/slsa_types.go
+++ b/sourcetool/pkg/slsa/slsa_types.go
@@ -24,6 +24,11 @@ const (
 	AllowedOrgPropPrefix                     = "ORG_SOURCE_"
 )
 
+// AllLevelControls lists all the SLSA controls managed by sourcetool
+var AllLevelControls = []ControlName{
+	ContinuityEnforced, ProvenanceAvailable, ReviewEnforced, TagHygiene,
+}
+
 func IsSlsaSourceLevel(control ControlName) bool {
 	return slices.Contains(
 		[]ControlName{


### PR DESCRIPTION
This PR adds a new `status` subcommand to check the status of a repo. For now we only report the repository status, once I check in the control automation, this command will issue recommendations. 

> [!NOTE]  
> This PR only adds methods and functions to support the new subcommand, none of the previous functionality is changed.

#### Sample runs and output: 

Checking this repo:
![image](https://github.com/user-attachments/assets/9837ae42-1d64-4179-b4f6-935b0e85b7ec)

Checking `opevex/go-vex`:
![image](https://github.com/user-attachments/assets/a4c911b2-cf19-411f-9d13-f1ba2877a38b)


#### `--help` output: 

```
sourcetool status: Check the SLSA Source status of a repo/branch

The status subcommand reads the current controls enabled for a branch
and reports the SLSA source level that the repository can claim. This
command is intended to help maintainers implementing SLSA controls
understand the next steps to secure their repos and progress in their
SLSA journey.

Usage:
  sourcetool status [flags]

Flags:
      --branch string       name of the branch
      --commit string       commit to check
  -h, --help                help for status
      --owner string        user or oganization that owns the repo
      --repository string   name of the repository

Global Flags:
      --expected_issuer string   The expected issuer of attestations.
      --expected_san string      The expect san of attestations.
      --github_token string      the github token to use for auth`
```
