### PR TITLE
Update verify to common options

### DIFF
--- a/sourcetool/cmd/options.go
+++ b/sourcetool/cmd/options.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+type repoOptions struct {
+	owner      string
+	repository string
+}
+
+func (ro *repoOptions) Validate() error {
+	errs := []error{}
+	if ro.owner == "" {
+		errs = append(errs, errors.New("repository owner not set"))
+	}
+	if ro.repository == "" {
+		errs = append(errs, errors.New(""))
+	}
+	return errors.Join(errs...)
+}
+
+// AddFlags adds the subcommands flags
+func (ro *repoOptions) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(
+		&ro.repository, "repo", "", "name of the repository",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&ro.owner, "owner", "", "user or oganization that owns the repo",
+	)
+}
+
+func (bo *branchOptions) Validate() error {
+	errs := []error{}
+	errs = append(errs, bo.repoOptions.Validate())
+
+	if bo.branch == "" {
+		return errors.New("branch not set")
+	}
+	return errors.Join(errs...)
+}
+
+// AddFlags adds the subcommands flags
+func (bo *branchOptions) AddFlags(cmd *cobra.Command) {
+	bo.repoOptions.AddFlags(cmd)
+
+	cmd.PersistentFlags().StringVar(
+		&bo.branch, "branch", "", "name of the branch",
+	)
+}
+
+type branchOptions struct {
+	repoOptions
+	branch string
+}
+
+// commitOptions defines the fields and flags to ask the user for the data of a commit
+type commitOptions struct {
+	branchOptions
+	commit string
+}
+
+func (co *commitOptions) AddFlags(cmd *cobra.Command) {
+	co.branchOptions.AddFlags(cmd)
+	cmd.PersistentFlags().StringVarP(
+		&co.commit, "commit", "c", "", "commit digest (sha1)",
+	)
+}
+
+func (co *commitOptions) Validate() error {
+	errs := []error{
+		co.branchOptions.Validate(),
+	}
+	if co.commit == "" {
+		errs = append(errs, errors.New("commit digest must be set"))
+	}
+	return errors.Join(errs...)
+}

--- a/sourcetool/cmd/root.go
+++ b/sourcetool/cmd/root.go
@@ -63,5 +63,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&expectedIssuer, "expected_issuer", "", "The expected issuer of attestations.")
 	rootCmd.PersistentFlags().StringVar(&expectedSan, "expected_san", "", "The expect san of attestations.")
 
+	addVerifyCommit(rootCmd)
 	addStatus(rootCmd)
 }

--- a/sourcetool/cmd/status.go
+++ b/sourcetool/cmd/status.go
@@ -72,10 +72,13 @@ type branchOptions struct {
 	branch string
 }
 
-// statusOptions
-type statusOptions struct {
+type commitOptions struct {
 	branchOptions
 	commit string
+}
+
+// statusOptions
+type statusOptions struct {
 }
 
 // Validate checks the options

--- a/sourcetool/cmd/status.go
+++ b/sourcetool/cmd/status.go
@@ -21,80 +21,22 @@ import (
 
 var w = color.New(color.FgHiWhite, color.BgBlack).SprintFunc()
 
-type repoOptions struct {
-	owner      string
-	repository string
-}
-
-func (ro *repoOptions) Validate() error {
-	errs := []error{}
-	if ro.owner == "" {
-		errs = append(errs, errors.New("repository owner not set"))
-	}
-	if ro.repository == "" {
-		errs = append(errs, errors.New(""))
-	}
-	return errors.Join(errs...)
-}
-
-// AddFlags adds the subcommands flags
-func (ro *repoOptions) AddFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(
-		&ro.repository, "repository", "", "name of the repository",
-	)
-
-	cmd.PersistentFlags().StringVar(
-		&ro.owner, "owner", "", "user or oganization that owns the repo",
-	)
-}
-
-func (bo *branchOptions) Validate() error {
-	errs := []error{}
-	errs = append(errs, bo.repoOptions.Validate())
-
-	if bo.branch == "" {
-		return errors.New("branch not set")
-	}
-	return errors.Join(errs...)
-}
-
-// AddFlags adds the subcommands flags
-func (bo *branchOptions) AddFlags(cmd *cobra.Command) {
-	bo.repoOptions.AddFlags(cmd)
-
-	cmd.PersistentFlags().StringVar(
-		&bo.branch, "branch", "", "name of the branch",
-	)
-}
-
-type branchOptions struct {
-	repoOptions
-	branch string
-}
-
-type commitOptions struct {
-	branchOptions
-	commit string
-}
-
 // statusOptions
 type statusOptions struct {
+	commitOptions
 }
 
 // Validate checks the options
 func (so *statusOptions) Validate() error {
 	errs := []error{}
-	errs = append(errs, so.branchOptions.Validate())
+	errs = append(errs, so.commitOptions.Validate())
 
 	return errors.Join(errs...)
 }
 
 // AddFlags adds the subcommands flags
 func (so *statusOptions) AddFlags(cmd *cobra.Command) {
-	so.branchOptions.AddFlags(cmd)
-	cmd.PersistentFlags().StringVar(
-		&so.commit, "commit", "", "commit to check",
-	)
+	so.commitOptions.AddFlags(cmd)
 }
 
 // TODO(puerco): Most of the logic in this subcommand (except maybe the output)


### PR DESCRIPTION
This pr modifies the `verifycommand` to use the common options structs. As we start to strengthen the CLI options structs, this will enable us to compute better defaults and removes the use of init()