### PR TITLE
Support repo slugs and defaults in verifycommit

### DIFF
--- a/sourcetool/cmd/options.go
+++ b/sourcetool/cmd/options.go
@@ -23,7 +23,7 @@ func (ro *repoOptions) Validate() error {
 		errs = append(errs, errors.New("repository owner not set"))
 	}
 	if ro.repository == "" {
-		errs = append(errs, errors.New(""))
+		errs = append(errs, errors.New("repository name not set"))
 	}
 	return errors.Join(errs...)
 }
@@ -91,6 +91,10 @@ func (bo *branchOptions) ParseLocator(lString string) error {
 }
 
 func (bo *branchOptions) EnsureDefaults() error {
+	if bo.owner == "" || bo.repository == "" {
+		return errors.New("unable to fetch branch defaults, repository data incomplete")
+	}
+
 	if bo.branch != "" {
 		return nil
 	}
@@ -145,6 +149,10 @@ func (co *commitOptions) ParseLocator(lString string) error {
 }
 
 func (co *commitOptions) EnsureDefaults() error {
+	if co.owner == "" || co.repository == "" {
+		return fmt.Errorf("unable to fetch commit defaults, repository data incomplete")
+	}
+
 	if err := co.branchOptions.EnsureDefaults(); err != nil {
 		return fmt.Errorf("fetching default branch of %s/%s: %w", co.owner, co.repository, err)
 	}

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -38,6 +38,19 @@ func addVerifyCommit(cmd *cobra.Command) {
 	verifyCommitCmd := &cobra.Command{
 		Use:   "verifycommit",
 		Short: "Verifies the specified commit is valid",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				if err := opts.ParseLocator(args[0]); err != nil {
+					return err
+				}
+			}
+
+			if err := opts.EnsureDefaults(); err != nil {
+				return err
+			}
+
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return fmt.Errorf("validating options: %w", err)

--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -45,6 +45,12 @@ func addVerifyCommit(cmd *cobra.Command) {
 				}
 			}
 
+			// Validate early the repository options to provide a more
+			// useful message to the user
+			if err := opts.repoOptions.Validate(); err != nil {
+				return err
+			}
+
 			if err := opts.EnsureDefaults(); err != nil {
 				return err
 			}

--- a/sourcetool/go.mod
+++ b/sourcetool/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/carabiner-dev/bnd v0.2.0
+	github.com/carabiner-dev/vcslocator v0.3.1
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-github/v69 v69.2.0
@@ -70,6 +71,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/sourcetool/go.sum
+++ b/sourcetool/go.sum
@@ -79,6 +79,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/carabiner-dev/bnd v0.2.0 h1:iD6qKPJeUW1pTi3DXYjcT2klUfW8kih1g2ic02WPxpQ=
 github.com/carabiner-dev/bnd v0.2.0/go.mod h1:ecogX7Dmh/fvsp1i0j2Nv3HT0FfBiPXJ8+Z7cQYnM40=
+github.com/carabiner-dev/vcslocator v0.3.1 h1:TIC7NfrBjMUkul9F+vvrDVIxxRqhsywjWy4L7WzdaMA=
+github.com/carabiner-dev/vcslocator v0.3.1/go.mod h1:jvYlXLVyqQqkBuSH/CiE1pbHifoPaAhWtUjLquHaBb0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
@@ -283,6 +285,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
+github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
@@ -70,14 +69,15 @@ func CreateUnsignedSourceVsa(repoUri, ref, commit string, verifiedLevels slsa.So
 // Gets provenance for the commit from git notes.
 func GetVsa(ctx context.Context, ghc *ghcontrol.GitHubConnection, verifier Verifier, commit, ref string) (*spb.Statement, *vpb.VerificationSummary, error) {
 	notes, err := ghc.GetNotesForCommit(ctx, commit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching commit note: %w", err)
+	}
+
 	if notes == "" {
 		Debugf("didn't find notes for commit %s", commit)
 		return nil, nil, nil
 	}
 
-	if err != nil {
-		log.Fatal(err)
-	}
 	return getVsaFromReader(NewBundleReader(bufio.NewReader(strings.NewReader(notes)), verifier), commit, ref)
 }
 

--- a/sourcetool/pkg/ghcontrol/connection.go
+++ b/sourcetool/pkg/ghcontrol/connection.go
@@ -99,3 +99,13 @@ func (ghc *GitHubConnection) GetLatestCommit(ctx context.Context, targetBranch s
 	}
 	return *branch.Commit.SHA, nil
 }
+
+// GetDefaultBranch reads the default repository branch from the GitHub API
+func (ghc *GitHubConnection) GetDefaultBranch(ctx context.Context) (string, error) {
+	repo, _, err := ghc.Client().Repositories.Get(ctx, ghc.owner, ghc.repo)
+	if err != nil {
+		return "", fmt.Errorf("fetching repository data: %w", err)
+	}
+
+	return repo.GetDefaultBranch(), nil
+}


### PR DESCRIPTION
This PR adds the capability to compute defaults for the branch and commit flags in verify commit and also to support specifying the repo + commit to verify as a slug / short VCS locator. So this:

```
sourcetool verifycommit  --owner=slsa-framework --repo=slsa-source-poc 
  --branch=main --commit=9c70035b6f66fdaec0a9865eda17fd20df47ce02
```

Now can be specified as:

```
sourcetool verifycommit  slsa-framework/slsa-source-poc 

# The commit can be specified as the slug is a short VCS locator:
sourcetool verifycommit  -slsa-framework/slsa-source-poc@9c70035b6f66fdaec0a9865eda17fd20df47ce02
```
![image](https://github.com/user-attachments/assets/e7f58dc9-3f16-46ca-b7c9-26e0856f837f)

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>
