### PR TITLE
Add sourcetool package, move setup logic

### DIFF
--- a/sourcetool/pkg/sourcetool/implementation.go
+++ b/sourcetool/pkg/sourcetool/implementation.go
@@ -1,0 +1,62 @@
+package sourcetool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
+)
+
+// toolImplementation defines the mockable implementation of source tool
+type toolImplementation interface {
+	GetActiveControls(*Options) (slsa.Controls, error)
+}
+
+type defaultToolImplementation struct{}
+
+// GetActiveControls returns a slsa.Controls with the active controls on a repo
+func (impl *defaultToolImplementation) GetActiveControls(opts *Options) (slsa.Controls, error) {
+	ctx := context.Background()
+
+	ghc, err := opts.GetGitHubConnection()
+	if err != nil {
+		return nil, fmt.Errorf("getting GitHub connection: %w", err)
+	}
+
+	if err := opts.EnsureBranch(); err != nil {
+		return nil, err
+	}
+
+	if err := opts.EnsureCommit(); err != nil {
+		return nil, err
+	}
+
+	// Get the active controls
+	activeControls, err := ghc.GetBranchControls(ctx, opts.Commit, ghcontrol.BranchToFullRef(opts.Branch))
+	if err != nil {
+		return nil, fmt.Errorf("checking status: %w", err)
+	}
+
+	ret := activeControls.Controls
+
+	// We need to manually check for PROVENANCE_AVAILABLE which is not
+	// handled by ghcontrol
+	attestor := attest.NewProvenanceAttestor(
+		ghc, attest.GetDefaultVerifier(),
+	)
+
+	// Fetch the attestation. If found, then add the control:
+	attestation, _, err := attestor.GetProvenance(ctx, opts.Commit, ghcontrol.BranchToFullRef(opts.Branch))
+	if err != nil {
+		return nil, fmt.Errorf("attempting to read provenance from commit: %w", err)
+	}
+	if attestation != nil {
+		ret.AddControl(&slsa.Control{
+			Name: slsa.ProvenanceAvailable,
+		})
+	}
+
+	return ret, nil
+}

--- a/sourcetool/pkg/sourcetool/options.go
+++ b/sourcetool/pkg/sourcetool/options.go
@@ -1,0 +1,108 @@
+package sourcetool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+)
+
+type Options struct {
+	Repo   string
+	Owner  string
+	Branch string
+	Commit string
+}
+
+// DefaultOptions holds the default options the tool initializes with
+var DefaultOptions = Options{}
+
+// GetGitHubConnection creates a new github connection to the repository
+// defined in the options set.
+func (o *Options) GetGitHubConnection() (*ghcontrol.GitHubConnection, error) {
+	if o.Owner == "" {
+		return nil, errors.New("owner not set")
+	}
+	if o.Repo == "" {
+		return nil, errors.New("repository not set")
+	}
+
+	return ghcontrol.NewGhConnection(o.Owner, o.Repo, o.Branch), nil
+}
+
+// EnsureCommit checks the options have a commit sha defined. If not, then
+// the latest commit from the loaded branch is read from the GitHub API.
+func (o *Options) EnsureCommit() error {
+	if o.Commit != "" {
+		return nil
+	}
+
+	if o.Branch == "" {
+		return errors.New("unable to fetch latest commit, no branch defined")
+	}
+
+	ghc, err := o.GetGitHubConnection()
+	if err != nil {
+		return fmt.Errorf("getting GitHub connection: %w", err)
+	}
+
+	commit, err := ghc.GetLatestCommit(context.Background(), o.Branch)
+	if err != nil {
+		return fmt.Errorf("fetching latest commit: %w", err)
+	}
+	o.Commit = commit
+	return nil
+}
+
+// EnsureBranch checks that the options set has a branch set and if not, it
+// reads the repository's default branch from the GitHub API.
+func (o *Options) EnsureBranch() error {
+	if o.Branch != "" {
+		return nil
+	}
+
+	ghc, err := o.GetGitHubConnection()
+	if err != nil {
+		return fmt.Errorf("getting GitHub connection: %w", err)
+	}
+
+	branch, err := ghc.GetDefaultBranch(context.Background())
+	if err != nil {
+		return fmt.Errorf("fetching default branch: %w", err)
+	}
+	o.Branch = branch
+	return nil
+}
+
+type ooFn func(*Options) error
+
+func WithRepo(repo string) ooFn {
+	return func(o *Options) error {
+		// TODO(puerco): Validate repo string
+		o.Repo = repo
+		return nil
+	}
+}
+
+func WithOwner(repo string) ooFn {
+	return func(o *Options) error {
+		// TODO(puerco): Validate org string
+		o.Owner = repo
+		return nil
+	}
+}
+
+func WithBranch(branch string) ooFn {
+	return func(o *Options) error {
+		o.Branch = branch
+		return nil
+	}
+}
+
+func WithCommit(commit string) ooFn {
+	return func(o *Options) error {
+		o.Commit = commit
+		return nil
+	}
+}

--- a/sourcetool/pkg/sourcetool/tool.go
+++ b/sourcetool/pkg/sourcetool/tool.go
@@ -1,0 +1,40 @@
+package sourcetool
+
+import (
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
+)
+
+// New initializes a new source tool instance.
+func New(funcs ...ooFn) (*Tool, error) {
+	opts := DefaultOptions
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Tool{
+		Options: opts,
+		impl:    &defaultToolImplementation{},
+	}, nil
+}
+
+// Tool is the main object intended to expose sourcetool's functionality as a
+// public API. Some of the logic is still implemented on the CLI commands but
+// we want to slowly move it to public function under this struct.
+type Tool struct {
+	Options Options
+	impl    toolImplementation
+}
+
+// GetRepoControls returns the controls that are enabled in a repository.
+func (t *Tool) GetRepoControls(funcs ...ooFn) (slsa.Controls, error) {
+	opts := t.Options
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, err
+		}
+	}
+
+	return t.impl.GetActiveControls(&opts)
+}


### PR DESCRIPTION
This PR introduces the public package `sourcetool` that is intended to expose the tool's functionality as a public API. 

Internally, the tool implementation uses a mockable interface that, in this PR, only exposes one method. The upcoming PRs will start adding the repository onboarding logic to the tool implementation.

The single method included moves the `sourcetool status` logic to the new package with the aim of making the CLI just a thin layer that calls the new `sourcetool` package.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>