### PR TITLE
print branch with verify

### DIFF
--- a/sourcetool/cmd/verifycommit.go
+++ b/sourcetool/cmd/verifycommit.go
@@ -95,6 +95,6 @@ func doVerifyCommit(commit, owner, repo, branch, tag string) error {
 		return nil
 	}
 
-	fmt.Printf("SUCCESS: commit %s verified with %v\n", commit, vsaPred.GetVerifiedLevels())
+	fmt.Printf("SUCCESS: commit %s on %s verified with %v\n", commit, branch, vsaPred.GetVerifiedLevels())
 	return nil
 }


### PR DESCRIPTION
If we infer the branch users might not know which branch we verified the thing on.

This prints the branch with the verify results.