### PR TITLE
Improve attestation verification

### DIFF
--- a/sourcetool/pkg/attest/provenance.go
+++ b/sourcetool/pkg/attest/provenance.go
@@ -201,13 +201,14 @@ func (pa ProvenanceAttestor) getProvFromReader(reader *BundleReader, commit, ref
 			break
 		}
 
-		prevProdPred, err := GetSourceProvPred(stmt)
+		// We know the statement is good, what about the predicate?
+		provPred, err := GetSourceProvPred(stmt)
 		if err != nil {
 			return nil, nil, err
 		}
-		if ref == ghcontrol.AnyReference || prevProdPred.Branch == ref {
+		if pa.gh_connection.GetRepoUri() == provPred.RepoUri && (ref == ghcontrol.AnyReference || provPred.Branch == ref) {
 			// Should be good!
-			return stmt, prevProdPred, nil
+			return stmt, provPred, nil
 		} else {
 			Debugf("prov '%v' does not reference commit '%s' for branch '%s', skipping", stmt, commit, ref)
 		}

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -168,7 +168,7 @@ func TestReadProvFailure(t *testing.T) {
 }
 
 func TestCreateTagProvenance(t *testing.T) {
-	testVsa := createTestVsa(t, "http://repo", "refs/some/ref", "abc123", slsa.SourceVerifiedLevels{"TEST_LEVEL"})
+	testVsa := createTestVsa(t, "https://github.com/owner/repo", "refs/some/ref", "abc123", slsa.SourceVerifiedLevels{"TEST_LEVEL"})
 
 	ghc := newTestGhConnection("owner", "repo", "branch",
 		newTagHygieneRulesetsResponse(123, github.RulesetTargetTag,

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -151,8 +151,8 @@ func TestReadProvFailure(t *testing.T) {
 	testProv := createTestProv(t, "foo", "main", "abc123")
 	ghc := newTestGhConnection("owner", "repo", "branch",
 		// We just need _some_ rulesets response, we don't care what.
-		newTagHygieneRulesetsResponse(123, github.RulesetTargetTag,
-			github.RulesetEnforcementActive, rulesetOldTime),
+		newTagHygieneRulesetsResponse(456, github.RulesetTargetBranch,
+			github.RulesetEnforcementEvaluate, rulesetOldTime),
 		newNotesContent(testProv))
 	verifier := testsupport.NewMockVerifier()
 

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -33,7 +33,6 @@ func conditionsForTagImmutability() *github.RepositoryRulesetConditions {
 }
 
 func createTestProv(t *testing.T, repoUri, ref, commit string) string {
-
 	provPred := SourceProvenancePred{RepoUri: repoUri, Branch: ref, ActivityType: "pr_merge", Actor: "test actor"}
 	stmt, err := addPredToStatement(provPred, SourceProvPredicateType, commit)
 	if err != nil {

--- a/sourcetool/pkg/attest/statement.go
+++ b/sourcetool/pkg/attest/statement.go
@@ -23,6 +23,7 @@ func NewBundleReader(reader *bufio.Reader, verifier Verifier) *BundleReader {
 
 func (br *BundleReader) convertLineToStatement(line string) (*spb.Statement, error) {
 	// Is this a sigstore bundle with a statement?
+	// Verify will check the signature, but nothing else.
 	vr, err := br.verifier.Verify(line)
 	if err == nil {
 		// This is it.
@@ -79,8 +80,9 @@ func MatchesTypeAndCommit(predicateType, commit string) StatementMatcher {
 }
 
 // Reads all the statements that:
-// 1. Have the specified predicate type.
-// 2. Have a subject that matches the specified git commit.
+// 1. Have a valid signature
+// 2. Have the specified predicate type.
+// 3. Have a subject that matches the specified git commit.
 func (br *BundleReader) ReadStatement(matcher StatementMatcher) (*spb.Statement, error) {
 	// Read until we get a statement or end of file.
 	for {

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -66,7 +66,7 @@ func CreateUnsignedSourceVsa(repoUri, ref, commit string, verifiedLevels slsa.So
 	return string(statement), nil
 }
 
-// Gets provenance for the commit from git notes.
+// Gets a VSA for the commit from git notes.
 func GetVsa(ctx context.Context, ghc *ghcontrol.GitHubConnection, verifier Verifier, commit, ref string) (*spb.Statement, *vpb.VerificationSummary, error) {
 	notes, err := ghc.GetNotesForCommit(ctx, commit)
 	if err != nil {
@@ -119,6 +119,10 @@ func MatchesTypeCommitAndRef(predicateType, commit, targetRef string) StatementM
 }
 
 func getVsaFromReader(reader *BundleReader, commit, ref string) (*spb.Statement, *vpb.VerificationSummary, error) {
+	// We want to return the first valid VSA.
+	// We should follow instructions from
+	// https://slsa.dev/spec/draft/verifying-source#how-to-verify-slsa-a-source-revision
+
 	for {
 		stmt, err := reader.ReadStatement(MatchesTypeCommitAndRef(VsaPredicateType, commit, ref))
 		if err != nil {

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -16,8 +16,10 @@ import (
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
-const VsaPredicateType = "https://slsa.dev/verification_summary/v1"
-const VsaVerifierId = "https://github.com/slsa-framework/slsa-source-poc"
+const (
+	VsaPredicateType = "https://slsa.dev/verification_summary/v1"
+	VsaVerifierId    = "https://github.com/slsa-framework/slsa-source-poc"
+)
 
 func CreateUnsignedSourceVsa(repoUri, ref, commit string, verifiedLevels slsa.SourceVerifiedLevels, policy string) (string, error) {
 	return createUnsignedSourceVsaAllParams(repoUri, ref, commit, verifiedLevels, policy, VsaVerifierId, "PASSED")

--- a/sourcetool/pkg/attest/vsa.go
+++ b/sourcetool/pkg/attest/vsa.go
@@ -149,22 +149,22 @@ func getVsaFromReader(reader *BundleReader, commit, ref, repoUri string) (*spb.S
 		}
 
 		// Is it the verifier ID we expect?
-		if vsaPred.Verifier.Id != VsaVerifierId {
-			Debugf("we do not accept Verifier.Id %s", vsaPred.Verifier.Id)
+		if vsaPred.GetVerifier().GetId() != VsaVerifierId {
+			Debugf("we do not accept Verifier.Id %s", vsaPred.GetVerifier().GetId())
 			continue
 		}
 
 		// Does repo match?
 		// remove git+http:// from resourceUri
-		cleanResourceUri := strings.TrimPrefix(vsaPred.ResourceUri, "git+")
+		cleanResourceUri := strings.TrimPrefix(vsaPred.GetResourceUri(), "git+")
 		if cleanResourceUri != repoUri {
 			Debugf("ResourceUri is %s but we want %s", cleanResourceUri, repoUri)
 			continue
 		}
 
 		// Is the result PASSED?
-		if vsaPred.VerificationResult != "PASSED" {
-			Debugf("verificationResult is %s but must be PASSED", vsaPred.VerificationResult)
+		if vsaPred.GetVerificationResult() != "PASSED" {
+			Debugf("verificationResult is %s but must be PASSED", vsaPred.GetVerificationResult())
 			continue
 		}
 

--- a/sourcetool/pkg/attest/vsa_test.go
+++ b/sourcetool/pkg/attest/vsa_test.go
@@ -1,0 +1,103 @@
+package attest
+
+// TODO: This test package uses some functions that live in provenance_test.go
+// that seems ugly and maybe we should fix it.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/go-github/v69/github"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/testsupport"
+)
+
+func createTestVsa(t *testing.T, repoUri, ref, commit string, verifiedLevels slsa.SourceVerifiedLevels) string {
+	vsa, err := CreateUnsignedSourceVsa(repoUri, ref, commit, verifiedLevels, "test-policy")
+	if err != nil {
+		t.Fatalf("failure creating test vsa: %v", err)
+	}
+	return vsa
+}
+
+func createTestVsaWithIdAndResult(t *testing.T, repoUri, ref, commit, id, result string, verifiedLevels slsa.SourceVerifiedLevels) string {
+	vsa, err := createUnsignedSourceVsaAllParams(repoUri, ref, commit, verifiedLevels, "test-policy", id, result)
+	if err != nil {
+		t.Fatalf("failure creating test vsa: %v", err)
+	}
+	return vsa
+}
+
+func TestReadVsaSuccess(t *testing.T) {
+	testVsa := createTestVsa(t, "https://github.com/owner/repo", "refs/some/ref", "abc123", slsa.SourceVerifiedLevels{"TEST_LEVEL"})
+	ghc := newTestGhConnection("owner", "repo", "branch",
+		// We just need _some_ rulesets response, we don't care what.
+		newTagHygieneRulesetsResponse(123, github.RulesetTargetTag,
+			github.RulesetEnforcementActive, rulesetOldTime),
+		newNotesContent(testVsa))
+	verifier := testsupport.NewMockVerifier()
+
+	readStmt, readPred, err := GetVsa(t.Context(), ghc, verifier, "abc123", "refs/some/ref")
+	if err != nil {
+		t.Fatalf("error finding vsa: %v", err)
+	}
+	if readStmt == nil || readPred == nil {
+		t.Errorf("could not find vsa")
+	}
+
+	if !slices.Contains(readPred.GetVerifiedLevels(), "TEST_LEVEL") {
+		t.Errorf("expected VSA to contain TEST_LEVEL, but it just contains %v", readPred.GetVerifiedLevels())
+	}
+}
+
+func TestReadVsaInvalidVsas(t *testing.T) {
+	goodRepo := "https://github.com/org/foo"
+	goodRef := "refs/heads/main"
+	goodCommit := "abc123"
+
+	// We want to make sure invalid VSAs aren't returned.
+	tests := []struct {
+		name string
+		vsa  string
+	}{
+		{
+			name: "wrong commit",
+			vsa:  createTestVsa(t, goodRepo, goodRef, "def456", slsa.SourceVerifiedLevels{}),
+		},
+		{
+			name: "wrong repo uri",
+			vsa:  createTestVsa(t, "https://github.com/foo/bar", goodRef, goodCommit, slsa.SourceVerifiedLevels{}),
+		},
+		{
+			name: "wrong ref",
+			vsa:  createTestVsa(t, goodRepo, "refs/heads/bad", goodCommit, slsa.SourceVerifiedLevels{}),
+		},
+		{
+			name: "wrong verifier ID",
+			vsa:  createTestVsaWithIdAndResult(t, goodRepo, goodRef, goodCommit, "bad id", "PASSED", slsa.SourceVerifiedLevels{}),
+		},
+		{
+			name: "bad result",
+			vsa:  createTestVsaWithIdAndResult(t, goodRepo, goodRef, goodCommit, VsaVerifierId, "FAILED", slsa.SourceVerifiedLevels{}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ghc := newTestGhConnection("org", "foo", "main",
+				// We just need _some_ rulesets response, we don't care what.
+				newTagHygieneRulesetsResponse(123, github.RulesetTargetTag,
+					github.RulesetEnforcementActive, rulesetOldTime),
+				newNotesContent(tt.vsa))
+			verifier := testsupport.NewMockVerifier()
+
+			_, readPred, err := GetVsa(t.Context(), ghc, verifier, "abc123", "refs/heads/main")
+			if err != nil {
+				t.Fatalf("error finding vsa: %v", err)
+			}
+			if readPred != nil {
+				t.Errorf("should not have gotten vsa: %+v", readPred)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We weren't always checking the fields in the attestations that we should have.

With this change we check the expected properties in the VSA per https://slsa.dev/spec/draft/verification_summary#how-to-verify.

We also check the repo URI in the provenance.

fixes #148