### PR TITLE
Support unsharded notes blobs

### DIFF
--- a/sourcetool/pkg/ghcontrol/notes.go
+++ b/sourcetool/pkg/ghcontrol/notes.go
@@ -8,7 +8,9 @@ import (
 	"github.com/google/go-github/v69/github"
 )
 
-// GetNotesForCommit returns the unparsed notes blob for a commit as stored in git via the GitHub API.
+// GetNotesForCommit returns the unparsed notes blob for a commit as stored in
+// git via the GitHub API. If no notes data can be found at the specified commit
+// GetNotesForCommit returns a blank string (and no error).
 func (ghc *GitHubConnection) GetNotesForCommit(ctx context.Context, commit string) (string, error) {
 	// We can find the notes for a given commit fairly easily.
 	// They'll be in the path <co/mmit> within ref `refs/notes/commits`
@@ -19,8 +21,19 @@ func (ghc *GitHubConnection) GetNotesForCommit(ctx context.Context, commit strin
 		ctx, ghc.Owner(), ghc.Repo(), path, &github.RepositoryContentGetOptions{Ref: "refs/notes/commits"})
 
 	if resp.StatusCode == http.StatusNotFound {
-		// Don't freak out if it's not there.
-		return "", nil
+		// If we got a 404, look for the note in a file at the top-level
+		// directory of refs/notes/commits. We brute force this call after
+		// trying the sharded path above as notes will be found using this
+		// path only when there is a small number of notes in the repo.
+		//
+		// See  https://github.com/slsa-framework/slsa-source-poc/issues/215
+		contents, _, resp, err = ghc.Client().Repositories.GetContents(
+			ctx, ghc.Owner(), ghc.Repo(), commit,
+			&github.RepositoryContentGetOptions{Ref: "refs/notes/commits"},
+		)
+		if resp.StatusCode == http.StatusNotFound {
+			return "", nil
+		}
 	}
 	if err != nil {
 		return "", fmt.Errorf("cannot get note contents for commit %s: %w", commit, err)
@@ -29,6 +42,5 @@ func (ghc *GitHubConnection) GetNotesForCommit(ctx context.Context, commit strin
 		// No notes stored for this commit.
 		return "", nil
 	}
-
 	return contents.GetContent()
 }


### PR DESCRIPTION
This PR adds support for reading notes stored as top-level files in addition to sharded subdirectories.

Fixes https://github.com/slsa-framework/slsa-source-poc/issues/215

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>