### PR TITLE
Add recommended actions to sourcetool status

### DIFF
--- a/sourcetool/internal/cmd/status.go
+++ b/sourcetool/internal/cmd/status.go
@@ -137,6 +137,17 @@ sourcetool status myorg/myrepo@mybranch
 				if slices.Contains(controls.Names(), c) {
 					fmt.Println("✅")
 				} else {
+					if c == "PROVENANCE_AVAILABLE" {
+						prdata, err := srctool.FindWorkflowPR()
+						if err != nil {
+							return err
+						}
+
+						if prdata != nil {
+							fmt.Printf("⏳ (PR %s/%s#%d waiting to merge)\n", prdata.Owner, prdata.Repo, prdata.Number)
+							continue
+						}
+					}
 					fmt.Println("🚫")
 				}
 			}

--- a/sourcetool/internal/cmd/status.go
+++ b/sourcetool/internal/cmd/status.go
@@ -96,6 +96,8 @@ sourcetool status myorg/myrepo@mybranch
 
 			cmd.SilenceUsage = true
 
+			actions := []recommendedAction{}
+
 			ctx := context.Background()
 			ghc := ghcontrol.NewGhConnection(opts.owner, opts.repository, opts.branch)
 
@@ -110,10 +112,19 @@ sourcetool status myorg/myrepo@mybranch
 				return err
 			}
 
+			// Get the active repository controls
 			controls, err := srctool.GetRepoControls()
 			if err != nil {
 				return fmt.Errorf("fetching active controls: %w", err)
 			}
+
+			// Check if the user has a fork of the policy repo:
+			policyForkFound, err := srctool.CheckPolicyRepoFork()
+			if err != nil {
+				return fmt.Errorf("checking for a fork of the policy repo: %w", err)
+			}
+
+			// Check if the user has a fork of the repository we want to protect
 
 			// Check if there is a policy:
 			pcy, _, err := policy.NewPolicyEvaluator().GetPolicy(ctx, ghc)
@@ -125,7 +136,7 @@ sourcetool status myorg/myrepo@mybranch
 			toplevel := policy.ComputeEligibleSlsaLevel(controls)
 
 			title := fmt.Sprintf(
-				"SLSA Source Status for %s/%s@%s", opts.owner, opts.repository,
+				"\nSLSA Source Status for %s/%s@%s", opts.owner, opts.repository,
 				ghcontrol.BranchToFullRef(opts.branch),
 			)
 			fmt.Printf("")
@@ -137,7 +148,9 @@ sourcetool status myorg/myrepo@mybranch
 				if slices.Contains(controls.Names(), c) {
 					fmt.Println("✅")
 				} else {
-					if c == "PROVENANCE_AVAILABLE" {
+					//nolint:exhaustive // We don't display all labels here
+					switch c {
+					case slsa.ProvenanceAvailable:
 						prdata, err := srctool.FindWorkflowPR()
 						if err != nil {
 							return err
@@ -145,8 +158,21 @@ sourcetool status myorg/myrepo@mybranch
 
 						if prdata != nil {
 							fmt.Printf("⏳ (PR %s/%s#%d waiting to merge)\n", prdata.Owner, prdata.Repo, prdata.Number)
+							actions = append(actions, recommendedAction{
+								Text: "Merge provenance workflow pull request",
+							})
 							continue
 						}
+
+						actions = append(actions, recommendedAction{
+							Text:    fmt.Sprintf("Start generating provenance on %s/%s", opts.owner, opts.repository),
+							Command: fmt.Sprintf("sourcetool setup controls --config=CONFIG_PROVENANCE_WORKFLOW %s/%s", opts.owner, opts.repository),
+						})
+					case slsa.ContinuityEnforced:
+						actions = append(actions, recommendedAction{
+							Text:    "Enable branch push/delete protection",
+							Command: fmt.Sprintf("sourcetool setup controls --config=CONFIG_BRANCH_RULES %s/%s", opts.owner, opts.repository),
+						})
 					}
 					fmt.Println("🚫")
 				}
@@ -155,7 +181,30 @@ sourcetool status myorg/myrepo@mybranch
 			fmt.Println("")
 			fmt.Printf("%-35s  ", "Repo policy found:")
 			if pcy == nil {
-				fmt.Println("🚫")
+				prdata, err := srctool.FindPolicyPR()
+				if err != nil {
+					return fmt.Errorf("looking for policy PR: %w", err)
+				}
+
+				if prdata != nil {
+					fmt.Printf("⏳ (PR %s/%s#%d waiting to merge)\n", prdata.Owner, prdata.Repo, prdata.Number)
+					actions = append(actions, recommendedAction{
+						Text: "Wait for policy pull request to merge",
+					})
+				} else {
+					if policyForkFound {
+						actions = append(actions, recommendedAction{
+							Text:    fmt.Sprintf("Create and commit a source policy for %s/%s", opts.owner, opts.repository),
+							Command: fmt.Sprintf("sourcetool setup controls --config=CONFIG_POLICY %s/%s", opts.owner, opts.repository),
+						})
+					} else {
+						actions = append(actions, recommendedAction{
+							Text:    fmt.Sprintf("Create a fork of the SLSA policies repo (%s)", srctool.Options.PolicyRepo),
+							Command: fmt.Sprintf("Open https://github.com/%s/fork", srctool.Options.PolicyRepo),
+						})
+					}
+					fmt.Println("🚫")
+				}
 			} else {
 				fmt.Println("✅")
 			}
@@ -164,9 +213,24 @@ sourcetool status myorg/myrepo@mybranch
 			fmt.Println(w("Current SLSA Source level: " + toplevel))
 			fmt.Println("")
 
+			fmt.Println("Recommended actions:")
+
+			for _, a := range actions {
+				fmt.Printf(" - %s\n", a.Text)
+				if a.Command != "" {
+					fmt.Printf("   > %s\n", a.Command)
+				}
+				fmt.Println()
+			}
+
 			return nil
 		},
 	}
 	opts.AddFlags(statusCmd)
 	parentCmd.AddCommand(statusCmd)
+}
+
+type recommendedAction struct {
+	Text    string
+	Command string
 }

--- a/sourcetool/pkg/sourcetool/implementation.go
+++ b/sourcetool/pkg/sourcetool/implementation.go
@@ -249,6 +249,10 @@ func (impl *defaultToolImplementation) CheckWorkflowFork(opts *options.Options) 
 	userForkOrg := opts.UserForkOrg
 	userForkRepo := opts.Repo // For now we only support forks with the same name
 
+	if userForkOrg == "" {
+		return errors.New("unable to check for for, user org not set")
+	}
+
 	if err := kgithub.VerifyFork(
 		fmt.Sprintf("slsa-source-workflow-%d", time.Now().Unix()), userForkOrg, userForkRepo, opts.Owner, opts.Repo,
 	); err != nil {
@@ -338,8 +342,19 @@ func (impl *defaultToolImplementation) CheckPolicyFork(opts *options.Options) er
 	if !ok || policyRepo == "" {
 		return fmt.Errorf("unable to parse policy repository slug")
 	}
+
+	if opts.UserForkOrg == "" {
+		if err := getUserData(opts); err != nil {
+			return err
+		}
+	}
+
 	userForkOrg := opts.UserForkOrg
 	userForkRepo := policyRepo // For now we only support forks with the same name
+
+	if userForkOrg == "" {
+		return errors.New("unable to check for for, user org not set")
+	}
 
 	// Check the user has a fork of the slsa repo
 	if err := kgithub.VerifyFork(
@@ -455,7 +470,6 @@ func (impl *defaultToolImplementation) SearchPullRequest(opts *options.Options, 
 			State: "open",
 		},
 	)
-
 	if err != nil {
 		return 0, fmt.Errorf("listing pull requests: %w", err)
 	}

--- a/sourcetool/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
+++ b/sourcetool/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
@@ -99,6 +99,20 @@ type FakeToolImplementation struct {
 		result1 slsa.Controls
 		result2 error
 	}
+	SearchPullRequestStub        func(*options.Options, string) (int, error)
+	searchPullRequestMutex       sync.RWMutex
+	searchPullRequestArgsForCall []struct {
+		arg1 *options.Options
+		arg2 string
+	}
+	searchPullRequestReturns struct {
+		result1 int
+		result2 error
+	}
+	searchPullRequestReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	VerifyOptionsForFullOnboardStub        func(*options.Options) error
 	verifyOptionsForFullOnboardMutex       sync.RWMutex
 	verifyOptionsForFullOnboardArgsForCall []struct {
@@ -605,6 +619,71 @@ func (fake *FakeToolImplementation) GetActiveControlsReturnsOnCall(i int, result
 	}{result1, result2}
 }
 
+func (fake *FakeToolImplementation) SearchPullRequest(arg1 *options.Options, arg2 string) (int, error) {
+	fake.searchPullRequestMutex.Lock()
+	ret, specificReturn := fake.searchPullRequestReturnsOnCall[len(fake.searchPullRequestArgsForCall)]
+	fake.searchPullRequestArgsForCall = append(fake.searchPullRequestArgsForCall, struct {
+		arg1 *options.Options
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.SearchPullRequestStub
+	fakeReturns := fake.searchPullRequestReturns
+	fake.recordInvocation("SearchPullRequest", []interface{}{arg1, arg2})
+	fake.searchPullRequestMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeToolImplementation) SearchPullRequestCallCount() int {
+	fake.searchPullRequestMutex.RLock()
+	defer fake.searchPullRequestMutex.RUnlock()
+	return len(fake.searchPullRequestArgsForCall)
+}
+
+func (fake *FakeToolImplementation) SearchPullRequestCalls(stub func(*options.Options, string) (int, error)) {
+	fake.searchPullRequestMutex.Lock()
+	defer fake.searchPullRequestMutex.Unlock()
+	fake.SearchPullRequestStub = stub
+}
+
+func (fake *FakeToolImplementation) SearchPullRequestArgsForCall(i int) (*options.Options, string) {
+	fake.searchPullRequestMutex.RLock()
+	defer fake.searchPullRequestMutex.RUnlock()
+	argsForCall := fake.searchPullRequestArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeToolImplementation) SearchPullRequestReturns(result1 int, result2 error) {
+	fake.searchPullRequestMutex.Lock()
+	defer fake.searchPullRequestMutex.Unlock()
+	fake.SearchPullRequestStub = nil
+	fake.searchPullRequestReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeToolImplementation) SearchPullRequestReturnsOnCall(i int, result1 int, result2 error) {
+	fake.searchPullRequestMutex.Lock()
+	defer fake.searchPullRequestMutex.Unlock()
+	fake.SearchPullRequestStub = nil
+	if fake.searchPullRequestReturnsOnCall == nil {
+		fake.searchPullRequestReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.searchPullRequestReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeToolImplementation) VerifyOptionsForFullOnboard(arg1 *options.Options) error {
 	fake.verifyOptionsForFullOnboardMutex.Lock()
 	ret, specificReturn := fake.verifyOptionsForFullOnboardReturnsOnCall[len(fake.verifyOptionsForFullOnboardArgsForCall)]
@@ -685,6 +764,8 @@ func (fake *FakeToolImplementation) Invocations() map[string][][]interface{} {
 	defer fake.ensureDefaultsMutex.RUnlock()
 	fake.getActiveControlsMutex.RLock()
 	defer fake.getActiveControlsMutex.RUnlock()
+	fake.searchPullRequestMutex.RLock()
+	defer fake.searchPullRequestMutex.RUnlock()
 	fake.verifyOptionsForFullOnboardMutex.RLock()
 	defer fake.verifyOptionsForFullOnboardMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/sourcetool/pkg/sourcetool/tool.go
+++ b/sourcetool/pkg/sourcetool/tool.go
@@ -228,3 +228,21 @@ func (t *Tool) FindWorkflowPR(funcs ...options.Fn) (*PullRequestDetails, error) 
 		Number: prNr,
 	}, nil
 }
+
+func (t *Tool) CheckPolicyRepoFork(funcs ...options.Fn) (bool, error) {
+	opts := t.Options
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return false, err
+		}
+	}
+
+	if err := t.impl.CheckPolicyFork(&opts); err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		}
+		return false, err
+	} else {
+		return true, nil
+	}
+}

--- a/sourcetool/pkg/sourcetool/tool.go
+++ b/sourcetool/pkg/sourcetool/tool.go
@@ -161,3 +161,33 @@ func (t *Tool) ControlConfigurationDescr(config ControlConfiguration, funcs ...o
 		return ""
 	}
 }
+
+type PullRequestDetails struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+func (t *Tool) FindWorkflowPR(funcs ...options.Fn) (*PullRequestDetails, error) {
+	opts := t.Options
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, err
+		}
+	}
+
+	prNr, err := t.impl.SearchPullRequest(&opts, workflowCommitMessage)
+	if err != nil {
+		return nil, fmt.Errorf("searching pull for pull request: %w", err)
+	}
+
+	if prNr == 0 {
+		return nil, nil
+	}
+
+	return &PullRequestDetails{
+		Owner:  opts.Owner,
+		Repo:   opts.Repo,
+		Number: prNr,
+	}, nil
+}


### PR DESCRIPTION
This PR improves the status subcommand it will now provide the user with the recommended next steps securing their repo. The `sourcetool output` now gives the user actionable commands to run:

![image](https://github.com/user-attachments/assets/bfc8ca53-03e0-4e1b-b1bf-2df15b4bab99)

The tool can now query the GitHub APIs to look for its own PRs and incorporates their status on the status screen:

![image](https://github.com/user-attachments/assets/f5a11945-726b-4a9e-95e3-57d2950cc397)
