### PR TITLE
Generalize policy package

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -243,6 +243,7 @@ github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/carabiner-dev/ampel v0.0.0-20250209210344-7b306497c927/go.mod h1:KJBPGPxyllTdgWoMW/lD3KBa/KAvVznZXzgUQUyPFxs=
 github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193 h1:wD6nGN7gq5IQJ4qFF0V4Jpu8B2FM+9ZnwlUqN5scWxk=
 github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193/go.mod h1:sQEeCRjbikSoqB1+VmZmWK2R0u2NdauEXDab+VlS8pQ=
+github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250625055119-2ae04903ae66 h1:90vTDpwtvAhjdLGFkO5x4ARBwINJ+a2cop/CGkK1wF4=
 github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250625055119-2ae04903ae66/go.mod h1:ukILmafFM9No+4C5pM89sUs+7RFtB1We9DB9+OvItEM=
 github.com/carabiner-dev/ghrfs v0.3.2/go.mod h1:xRewpmbdE766e+XlKfcH+p/KcObAflOIwNq6s7TARb0=
 github.com/carabiner-dev/github v0.0.0-20250210222226-442fdacc1d16 h1:6ESg7ESScHJp/e4zHO1a1y6XDAJYTcK9N06mqbqBvUg=
@@ -646,6 +647,7 @@ k8s.io/client-go v0.32.2/go.mod h1:fpZ4oJXclZ3r2nDOv+Ux3XcJutfrwjKTCHz2H3sww94=
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
@@ -653,6 +655,7 @@ sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxO
 sigs.k8s.io/release-sdk v0.12.1/go.mod h1:nnB4tt1g0VXMUCIYzDzPVqNI896OQrWipE6WbyZ6FSk=
 sigs.k8s.io/release-sdk v0.12.2 h1:ncuHwUu8VWcZVVrNkjoUR8xGo6ibHg+AM6uMMD+IwuQ=
 sigs.k8s.io/release-sdk v0.12.2/go.mod h1:tlJgWPJLeRbWOvcyq1XrCZmLe8Yfn3H5U/LNtmBa0Nc=
+sigs.k8s.io/release-sdk v0.12.3 h1:gwti7Twx/8xvoAnir0tQzbIhw71lCKFqCdwmeUogDh4=
 sigs.k8s.io/release-sdk v0.12.3/go.mod h1:MsNuKVrCJI9YVi1cZOI2vBxEDeeDH8DAj4m7ZHdfU98=
 sigs.k8s.io/release-utils v0.8.5/go.mod h1:qsm5bdxdgoHkD8HsXpgme2/c3mdsNaiV53Sz2HmKeJA=
 sigs.k8s.io/release-utils v0.9.0/go.mod h1:xZoCJyajMJ0wtgGXWuznbC1r9dw7iJzMp/+dCkf1UGw=

--- a/sourcetool/go.mod
+++ b/sourcetool/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/carabiner-dev/vcslocator v0.3.1
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-billy/v6 v6.0.0-20250627091229-31e2a16eef30
-	github.com/go-git/go-git/v5 v5.16.2
 	github.com/go-git/go-git/v6 v6.0.0-20250711134917-1f24ae85fe16
 	github.com/google/go-github/v69 v69.2.0
 	github.com/google/uuid v1.6.0
@@ -64,6 +63,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/gcfg/v2 v2.0.2 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
+	github.com/go-git/go-git/v5 v5.16.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/sourcetool/internal/cmd/checklevel.go
+++ b/sourcetool/internal/cmd/checklevel.go
@@ -88,7 +88,7 @@ func doCheckLevel(cla *checkLevelOpts) error {
 	}
 	pe := policy.NewPolicyEvaluator()
 	pe.UseLocalPolicy = cla.useLocalPolicy
-	verifiedLevels, policyPath, err := pe.EvaluateControl(ctx, ghconnection, controlStatus)
+	verifiedLevels, policyPath, err := pe.EvaluateControl(ctx, cla.GetRepository(), cla.GetBranch(), controlStatus)
 	if err != nil {
 		return err
 	}

--- a/sourcetool/internal/cmd/checklevelprov.go
+++ b/sourcetool/internal/cmd/checklevelprov.go
@@ -100,7 +100,7 @@ func doCheckLevelProv(checkLevelProvArgs *checkLevelProvOpts) error {
 	// check p against policy
 	pe := policy.NewPolicyEvaluator()
 	pe.UseLocalPolicy = checkLevelProvArgs.useLocalPolicy
-	verifiedLevels, policyPath, err := pe.EvaluateSourceProv(ctx, ghconnection, prov)
+	verifiedLevels, policyPath, err := pe.EvaluateSourceProv(ctx, checkLevelProvArgs.GetRepository(), checkLevelProvArgs.GetBranch(), prov)
 	if err != nil {
 		return err
 	}

--- a/sourcetool/internal/cmd/checktag.go
+++ b/sourcetool/internal/cmd/checktag.go
@@ -76,7 +76,7 @@ func doCheckTag(args *checkTagOptions) error {
 	// check p against policy
 	pe := policy.NewPolicyEvaluator()
 	pe.UseLocalPolicy = args.useLocalPolicy
-	verifiedLevels, policyPath, err := pe.EvaluateTagProv(ctx, ghconnection, prov)
+	verifiedLevels, policyPath, err := pe.EvaluateTagProv(ctx, args.GetRepository(), prov)
 	if err != nil {
 		return err
 	}

--- a/sourcetool/internal/cmd/createpolicy.go
+++ b/sourcetool/internal/cmd/createpolicy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
 )
 
@@ -48,9 +47,10 @@ func addCreatePolicy(parentCmd *cobra.Command) {
 }
 
 func doCreatePolicy(opts *createPolicyOptions) error {
-	ghconnection := ghcontrol.NewGhConnection(opts.owner, opts.repository, ghcontrol.BranchToFullRef(opts.branch)).WithAuthToken(githubToken)
-	ctx := context.Background()
-	outpath, err := policy.CreateLocalPolicy(ctx, ghconnection, opts.policyRepoPath)
+	evaluator := policy.NewPolicyEvaluator()
+	outpath, err := evaluator.CreateLocalPolicy(
+		context.Background(), opts.GetRepository(), opts.GetBranch(), opts.policyRepoPath,
+	)
 	if err != nil {
 		return err
 	}

--- a/sourcetool/pkg/attest/provenance_test.go
+++ b/sourcetool/pkg/attest/provenance_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/provenance"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/testsupport"
 )
@@ -34,8 +35,8 @@ func conditionsForTagImmutability() *github.RepositoryRulesetConditions {
 }
 
 func createTestProv(t *testing.T, repoUri, ref, commit string) string {
-	provPred := SourceProvenancePred{RepoUri: repoUri, Branch: ref, ActivityType: "pr_merge", Actor: "test actor"}
-	stmt, err := addPredToStatement(provPred, SourceProvPredicateType, commit)
+	provPred := provenance.SourceProvenancePred{RepoUri: repoUri, Branch: ref, ActivityType: "pr_merge", Actor: "test actor"}
+	stmt, err := addPredToStatement(provPred, provenance.SourceProvPredicateType, commit)
 	if err != nil {
 		t.Fatalf("failure creating test prov: %v", err)
 	}
@@ -96,7 +97,7 @@ func timesEqualWithinMargin(t1, t2 time.Time, margin time.Duration) bool {
 	return diff <= margin
 }
 
-func assertTagProvPredsEqual(t *testing.T, actual, expected *TagProvenancePred) {
+func assertTagProvPredsEqual(t *testing.T, actual, expected *provenance.TagProvenancePred) {
 	if actual.Actor != expected.Actor {
 		t.Errorf("Actor %v does not match expected value %v", actual.Actor, expected.Actor)
 	}
@@ -186,8 +187,8 @@ func TestCreateTagProvenance(t *testing.T) {
 		t.Fatalf("returned statement is nil")
 	}
 
-	if stmt.GetPredicateType() != TagProvPredicateType {
-		t.Errorf("statement pred type %v does not match expected %v", stmt.GetPredicateType(), TagProvPredicateType)
+	if stmt.GetPredicateType() != provenance.TagProvPredicateType {
+		t.Errorf("statement pred type %v does not match expected %v", stmt.GetPredicateType(), provenance.TagProvPredicateType)
 	}
 
 	if !DoesSubjectIncludeCommit(stmt, "73f0a864c2c9af12e03dae433a6ff5f5e719d7aa") {
@@ -199,7 +200,7 @@ func TestCreateTagProvenance(t *testing.T) {
 		t.Fatalf("error getting tag prov %v", err)
 	}
 
-	expectedPred := TagProvenancePred{
+	expectedPred := provenance.TagProvenancePred{
 		RepoUri:   "https://github.com/owner/repo",
 		Actor:     "the-tag-pusher",
 		Tag:       "refs/tags/v1",
@@ -210,7 +211,7 @@ func TestCreateTagProvenance(t *testing.T) {
 				Since: rulesetOldTime,
 			},
 		},
-		VsaSummaries: []VsaSummary{
+		VsaSummaries: []provenance.VsaSummary{
 			{
 				SourceRefs:     []string{"refs/some/ref"},
 				VerifiedLevels: []slsa.ControlName{"TEST_LEVEL"},

--- a/sourcetool/pkg/audit/audit.go
+++ b/sourcetool/pkg/audit/audit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/provenance"
 )
 
 type Auditor struct {
@@ -21,7 +22,7 @@ type Auditor struct {
 type AuditCommitResult struct {
 	Commit   string
 	VsaPred  *vpb.VerificationSummary
-	ProvPred *attest.SourceProvenancePred
+	ProvPred *provenance.SourceProvenancePred
 	// The previous commit reported by GH.
 	GhPriorCommit   string
 	GhControlStatus *ghcontrol.GhControlStatus

--- a/sourcetool/pkg/provenance/predicate.go
+++ b/sourcetool/pkg/provenance/predicate.go
@@ -1,0 +1,44 @@
+package provenance
+
+import (
+	"time"
+
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
+)
+
+const (
+	SourceProvPredicateType = "https://github.com/slsa-framework/slsa-source-poc/source-provenance/v1-draft"
+	TagProvPredicateType    = "https://github.com/slsa-framework/slsa-source-poc/tag-provenance/v1-draft"
+)
+
+// The predicate that encodes source provenance data.
+// The git commit this corresponds to is encoded in the surrounding statement.
+type SourceProvenancePred struct {
+	// The commit preceding 'Commit' in the current context.
+	PrevCommit   string    `json:"prev_commit"`
+	RepoUri      string    `json:"repo_uri"`
+	ActivityType string    `json:"activity_type"`
+	Actor        string    `json:"actor"`
+	Branch       string    `json:"branch"`
+	CreatedOn    time.Time `json:"created_on"`
+	// TODO: get the author of the PR (if this was from a PR).
+
+	// The controls enabled at the time this commit was pushed.
+	Controls slsa.Controls `json:"controls"`
+}
+
+type TagProvenancePred struct {
+	RepoUri   string    `json:"repo_uri"`
+	Actor     string    `json:"actor"`
+	Tag       string    `json:"tag"`
+	CreatedOn time.Time `json:"created_on"`
+	// The tag related controls enabled at the time this tag was created/updated.
+	Controls     slsa.Controls `json:"controls"`
+	VsaSummaries []VsaSummary  `json:"vsa_summaries"`
+}
+
+// Summary of a summary
+type VsaSummary struct {
+	SourceRefs     []string           `json:"source_refs"`
+	VerifiedLevels []slsa.ControlName `json:"verifiedLevels"`
+}

--- a/sourcetool/pkg/sourcetool/backends/attestation/notes/backend.go
+++ b/sourcetool/pkg/sourcetool/backends/attestation/notes/backend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/auth"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/ghcontrol"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/provenance"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/sourcetool/models"
 )
 
@@ -60,7 +61,7 @@ func (b *Backend) GetCommitVsa(ctx context.Context, branch *models.Branch, commi
 }
 
 // GetCommitProvenance gets the provenance attestation of a commit in a branch
-func (b *Backend) GetCommitProvenance(ctx context.Context, branch *models.Branch, commit *models.Commit) (*attestation.Statement, *attest.SourceProvenancePred, error) {
+func (b *Backend) GetCommitProvenance(ctx context.Context, branch *models.Branch, commit *models.Commit) (*attestation.Statement, *provenance.SourceProvenancePred, error) {
 	gcx, err := b.getGitHubConnection(branch)
 	if err != nil {
 		return nil, nil, err

--- a/sourcetool/pkg/sourcetool/models/models.go
+++ b/sourcetool/pkg/sourcetool/models/models.go
@@ -10,7 +10,7 @@ import (
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	attestation "github.com/in-toto/attestation/go/v1"
 
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/provenance"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
 
@@ -22,7 +22,7 @@ import (
 //counterfeiter:generate . AttestationStorageReader
 type AttestationStorageReader interface {
 	GetCommitVsa(context.Context, *Branch, *Commit) (*attestation.Statement, *vpb.VerificationSummary, error)
-	GetCommitProvenance(context.Context, *Branch, *Commit) (*attestation.Statement, *attest.SourceProvenancePred, error)
+	GetCommitProvenance(context.Context, *Branch, *Commit) (*attestation.Statement, *provenance.SourceProvenancePred, error)
 }
 
 // VcsBackend abstracts a VCS or VCS hosting system that sourcetool
@@ -47,9 +47,10 @@ const (
 )
 
 type Commit struct {
-	SHA    string
-	Author string
-	Time   *time.Time
+	SHA     string
+	Author  string
+	Time    *time.Time
+	Message string
 }
 
 type Branch struct {

--- a/sourcetool/pkg/sourcetool/models/modelsfakes/fake_attestation_storage_reader.go
+++ b/sourcetool/pkg/sourcetool/models/modelsfakes/fake_attestation_storage_reader.go
@@ -7,12 +7,12 @@ import (
 
 	v1a "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	v1 "github.com/in-toto/attestation/go/v1"
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/attest"
+	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/provenance"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/sourcetool/models"
 )
 
 type FakeAttestationStorageReader struct {
-	GetCommitProvenanceStub        func(context.Context, *models.Branch, *models.Commit) (*v1.Statement, *attest.SourceProvenancePred, error)
+	GetCommitProvenanceStub        func(context.Context, *models.Branch, *models.Commit) (*v1.Statement, *provenance.SourceProvenancePred, error)
 	getCommitProvenanceMutex       sync.RWMutex
 	getCommitProvenanceArgsForCall []struct {
 		arg1 context.Context
@@ -21,12 +21,12 @@ type FakeAttestationStorageReader struct {
 	}
 	getCommitProvenanceReturns struct {
 		result1 *v1.Statement
-		result2 *attest.SourceProvenancePred
+		result2 *provenance.SourceProvenancePred
 		result3 error
 	}
 	getCommitProvenanceReturnsOnCall map[int]struct {
 		result1 *v1.Statement
-		result2 *attest.SourceProvenancePred
+		result2 *provenance.SourceProvenancePred
 		result3 error
 	}
 	GetCommitVsaStub        func(context.Context, *models.Branch, *models.Commit) (*v1.Statement, *v1a.VerificationSummary, error)
@@ -50,7 +50,7 @@ type FakeAttestationStorageReader struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAttestationStorageReader) GetCommitProvenance(arg1 context.Context, arg2 *models.Branch, arg3 *models.Commit) (*v1.Statement, *attest.SourceProvenancePred, error) {
+func (fake *FakeAttestationStorageReader) GetCommitProvenance(arg1 context.Context, arg2 *models.Branch, arg3 *models.Commit) (*v1.Statement, *provenance.SourceProvenancePred, error) {
 	fake.getCommitProvenanceMutex.Lock()
 	ret, specificReturn := fake.getCommitProvenanceReturnsOnCall[len(fake.getCommitProvenanceArgsForCall)]
 	fake.getCommitProvenanceArgsForCall = append(fake.getCommitProvenanceArgsForCall, struct {
@@ -77,7 +77,7 @@ func (fake *FakeAttestationStorageReader) GetCommitProvenanceCallCount() int {
 	return len(fake.getCommitProvenanceArgsForCall)
 }
 
-func (fake *FakeAttestationStorageReader) GetCommitProvenanceCalls(stub func(context.Context, *models.Branch, *models.Commit) (*v1.Statement, *attest.SourceProvenancePred, error)) {
+func (fake *FakeAttestationStorageReader) GetCommitProvenanceCalls(stub func(context.Context, *models.Branch, *models.Commit) (*v1.Statement, *provenance.SourceProvenancePred, error)) {
 	fake.getCommitProvenanceMutex.Lock()
 	defer fake.getCommitProvenanceMutex.Unlock()
 	fake.GetCommitProvenanceStub = stub
@@ -90,31 +90,31 @@ func (fake *FakeAttestationStorageReader) GetCommitProvenanceArgsForCall(i int) 
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeAttestationStorageReader) GetCommitProvenanceReturns(result1 *v1.Statement, result2 *attest.SourceProvenancePred, result3 error) {
+func (fake *FakeAttestationStorageReader) GetCommitProvenanceReturns(result1 *v1.Statement, result2 *provenance.SourceProvenancePred, result3 error) {
 	fake.getCommitProvenanceMutex.Lock()
 	defer fake.getCommitProvenanceMutex.Unlock()
 	fake.GetCommitProvenanceStub = nil
 	fake.getCommitProvenanceReturns = struct {
 		result1 *v1.Statement
-		result2 *attest.SourceProvenancePred
+		result2 *provenance.SourceProvenancePred
 		result3 error
 	}{result1, result2, result3}
 }
 
-func (fake *FakeAttestationStorageReader) GetCommitProvenanceReturnsOnCall(i int, result1 *v1.Statement, result2 *attest.SourceProvenancePred, result3 error) {
+func (fake *FakeAttestationStorageReader) GetCommitProvenanceReturnsOnCall(i int, result1 *v1.Statement, result2 *provenance.SourceProvenancePred, result3 error) {
 	fake.getCommitProvenanceMutex.Lock()
 	defer fake.getCommitProvenanceMutex.Unlock()
 	fake.GetCommitProvenanceStub = nil
 	if fake.getCommitProvenanceReturnsOnCall == nil {
 		fake.getCommitProvenanceReturnsOnCall = make(map[int]struct {
 			result1 *v1.Statement
-			result2 *attest.SourceProvenancePred
+			result2 *provenance.SourceProvenancePred
 			result3 error
 		})
 	}
 	fake.getCommitProvenanceReturnsOnCall[i] = struct {
 		result1 *v1.Statement
-		result2 *attest.SourceProvenancePred
+		result2 *provenance.SourceProvenancePred
 		result3 error
 	}{result1, result2, result3}
 }


### PR DESCRIPTION
This PR updates the policy package to use the new generic models (PullRequest. Branch, etc) instead of taking the github connector to perform the policy operations. This is is required to ensure the policy evaluator works with any future backend and not just GitHub.

To achieve this PR includes three changes:

1. In order to reuse the provenance predicate without loops, we now split the provenance predicates into their own package in 687182ea2e90e7839c109ccc014634b8ceaa1a75. This also has the added benefit that it is now isolated in preparation to generate it from protobuf definitions.
2. Starting in af6d51b20929f7d4dd97e9beb036a6fcdb16a360 all the policy evaluator functions take generic models instead of the github connection
3. Finally we drop the ghcontrol dependency on b9ee9cd948b819b0ea8252c1fe27c161a5a4da46 and update the CLI subcommands to use the new policy interfaces in b9ee9cd948b819b0ea8252c1fe27c161a5a4da46

The PR is large but the changes are scoped into commits which hopefully are easier to parse. All tests are passing and have only been adapted to the new function signatures.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>