### PR TITLE
Fix policy PR, add interactive mode

### DIFF
--- a/sourcetool/internal/cmd/options.go
+++ b/sourcetool/internal/cmd/options.go
@@ -91,8 +91,10 @@ type branchOptions struct {
 	branch string
 }
 
+// ParseLocator parses an SPDX locator string and assigns its components
+// to the branch options fields.
 func (bo *branchOptions) ParseLocator(lString string) error {
-	components, err := vcslocator.Locator(lString).Parse()
+	components, err := vcslocator.Locator(lString).Parse(vcslocator.WithRefAsBranch(true))
 	if err != nil {
 		return fmt.Errorf("parsing repository slug: %w", err)
 	}

--- a/sourcetool/internal/cmd/setup.go
+++ b/sourcetool/internal/cmd/setup.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/util"
 
-	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/policy"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/sourcetool"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/sourcetool/models"
 )
@@ -30,9 +29,10 @@ func (so *setupOpts) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(
 		&so.userForkOrg, "user-fork", "", "GitHub organization to look for forks of repos (for pull requests)",
 	)
-	cmd.PersistentFlags().StringVar(
-		&so.policyRepo, "policy-repo", fmt.Sprintf("%s/%s", policy.SourcePolicyRepoOwner, policy.SourcePolicyRepo), "repository to store the SLSA source policy",
-	)
+	// Uncomment when we support custom policy repos
+	// cmd.PersistentFlags().StringVar(
+	// 	&so.policyRepo, "policy-repo", fmt.Sprintf("%s/%s", policy.SourcePolicyRepoOwner, policy.SourcePolicyRepo), "repository to store the SLSA source policy",
+	// )
 
 	cmd.PersistentFlags().BoolVar(
 		&so.interactive, "interactive", true, "confirm before performing changes",

--- a/sourcetool/pkg/repo/clone.go
+++ b/sourcetool/pkg/repo/clone.go
@@ -99,8 +99,14 @@ func (c *Clone) AddRemote(name, url string) error {
 
 // PushToRemote pushes the active branch to the specified remote
 func (c *Clone) PushRemote(remoteName string) error {
+	refSpecs := []config.RefSpec{
+		config.RefSpec(fmt.Sprintf(
+			"+refs/heads/%s:refs/heads/%s", c.FeatureBranch, c.FeatureBranch,
+		)),
+	}
 	err := c.repo.Push(&git.PushOptions{
 		RemoteName: remoteName,
+		RefSpecs:   refSpecs,
 	})
 	if err != nil {
 		return fmt.Errorf("pushing to remote: %w", err)

--- a/sourcetool/pkg/repo/implementation.go
+++ b/sourcetool/pkg/repo/implementation.go
@@ -134,6 +134,12 @@ func (impl *defaultPrmImpl) CloneRepo(opts *options.PullRequestManagerOptions, a
 		return nil, fmt.Errorf("adding remote: %w", err)
 	}
 
+	// Create the feature branch
+	if err := clone.CreateFeatureBranch(); err != nil {
+		clone.Cleanup()
+		return nil, fmt.Errorf("creating feature branch locally: %w", err)
+	}
+
 	return clone, nil
 }
 


### PR DESCRIPTION
The main purpose of this PR is to fix a bug preventing the branch push when creating the policy PR. In addition it fixes a small bug where the `--pr ` flag was not being honored and introduces an `--interactive` mode and flag, on by default, that asks you before opening the policy pull request:

<img width="952" height="274" alt="image" src="https://github.com/user-attachments/assets/ed7f2bf2-8a4b-4826-933f-d724090c10f2" />

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>