### PR TITLE
Automate tag hygiene controls

### DIFF
--- a/sourcetool/internal/cmd/setup.go
+++ b/sourcetool/internal/cmd/setup.go
@@ -86,14 +86,20 @@ func AddSetupRepo(parent *cobra.Command) {
 	setupRepoCmd := &cobra.Command{
 		Short: "configure all the SLSA source features in a repository",
 		Long: `The setup repo subcommand is a "one shot" setup process enabling all
-the security controls required to get a repository to a specific SLSA level.
+the security controls required to get a repository to SLSA Source level 3.
 
 This command is ideal for new repositories or when you are sure the implemented
 changes will not disrupt existing workflows.
 
-To use this subcommand you need to export a GitHub token as an environment
+To run this command make sure sourcetool is authorized on the repository
+(try sourcetool auth whoami ) or export a GitHub token as an environment
 variable called GITHUB_TOKEN. The token needs admin permissions on the repo
 to configure the branch rules.
+
+If the SLSA controls are already enforce in the repository they will be left
+untouched.
+
+Alternatively, to enable each control individually use: sourcetool setup controls.
 
 `,
 		Use:           "repo owner/repo",
@@ -229,8 +235,12 @@ as an identity source.
 The values for --config are as follows:
 
 %s
-Configures push and delete protection in the repository, required to reach slsa
-source level 2+. 
+Configures push and delete branch protection in the repository, required to reach
+SLSA source level 2+. 
+
+%s
+Configures udpate, push and delete protection for all tags in the repository,
+this is required to reach SLSA source level 2+. 
 
 %s
 Opens a pull request in the repository to add the provenance generation workflow
@@ -247,7 +257,8 @@ repositories. Make sure you have a fork of the SLSA source policy repo and
 a fork of the repository you want to protect.
 
 `, w("sourcetool setup controls"), w2("configure a repository for SLSA source"),
-			w2(models.CONFIG_BRANCH_RULES), w2(models.CONFIG_GEN_PROVENANCE), w2(models.CONFIG_POLICY)),
+			w2(models.CONFIG_BRANCH_RULES), w2(models.CONFIG_TAG_RULES),
+			w2(models.CONFIG_GEN_PROVENANCE), w2(models.CONFIG_POLICY)),
 		Use:           "controls owner/repo --config=CONTROL1 --config=CONTROL2",
 		SilenceUsage:  false,
 		SilenceErrors: true,

--- a/sourcetool/internal/cmd/setup.go
+++ b/sourcetool/internal/cmd/setup.go
@@ -151,7 +151,7 @@ sourcetool is about to perform the following actions on your behalf:
   - %s.
 
 `,
-					srctool.ControlConfigurationDescr(opts.GetBranch(), models.CONFIG_POLICY),
+					srctool.ControlConfigurationDescr(opts.GetBranch(), models.CONFIG_TAG_RULES),
 					srctool.ControlConfigurationDescr(opts.GetBranch(), models.CONFIG_GEN_PROVENANCE),
 					srctool.ControlConfigurationDescr(opts.GetBranch(), models.CONFIG_BRANCH_RULES),
 				)
@@ -322,6 +322,11 @@ a fork of the repository you want to protect.
 				opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cs,
 			)
 			if err != nil {
+				// if strings.Contains(err.Error(), models.ErrProtectionAlreadyInPlace.Error()) {
+				if errors.Is(err, models.ErrProtectionAlreadyInPlace) {
+					fmt.Printf("\n   ℹ️  Controls already enabled on %s\n\n", opts.GetRepository().Path)
+					return nil
+				}
 				return fmt.Errorf("configuring controls: %w", err)
 			}
 

--- a/sourcetool/internal/cmd/status.go
+++ b/sourcetool/internal/cmd/status.go
@@ -165,13 +165,22 @@ sourcetool status myorg/myrepo@mybranch
 
 			fmt.Println(w("Current SLSA Source level: " + toplevel))
 			fmt.Println("")
-
-			fmt.Println("Recommended actions:")
-
+			titled := false
 			for _, status := range controls.Controls {
 				if status.RecommendedAction == nil {
 					continue
 				}
+
+				// Suggest creating the policy but only on the higher levels
+				if status.Name == slsa.PolicyAvailable && toplevel == slsa.SlsaSourceLevel1 {
+					continue
+				}
+
+				if !titled {
+					fmt.Println(w2("✨ Recommended actions:"))
+					titled = true
+				}
+
 				fmt.Printf(" - %s\n", status.RecommendedAction.Message)
 				if status.RecommendedAction.Command != "" {
 					fmt.Printf("   > %s\n", status.RecommendedAction.Command)

--- a/sourcetool/pkg/sourcetool/backends/vcs/github/github.go
+++ b/sourcetool/pkg/sourcetool/backends/vcs/github/github.go
@@ -190,6 +190,11 @@ func (b *Backend) ControlConfigurationDescr(branch *models.Branch, config models
 			"Open a pull request on the SLSA policy repo to check-in %s SLSA source policy",
 			repo.Path,
 		)
+	case models.CONFIG_TAG_RULES:
+		return fmt.Sprintf(
+			"Enable push/update/delete protection for all tags in %s",
+			repo.Path,
+		)
 	default:
 		return ""
 	}
@@ -234,6 +239,14 @@ func (b *Backend) getRecommendedAction(r *models.Repository, _ *models.Branch, c
 			return &slsa.ControlRecommendedAction{
 				Message: "Enable branch push/delete protection",
 				Command: fmt.Sprintf("sourcetool setup controls --config=%s %s", models.CONFIG_BRANCH_RULES, r.Path),
+			}
+		}
+		return nil
+	case slsa.TagHygiene:
+		if state == slsa.StateNotEnabled {
+			return &slsa.ControlRecommendedAction{
+				Message: "Enable tag push/update/delete protection",
+				Command: fmt.Sprintf("sourcetool setup controls --config=%s %s", models.CONFIG_TAG_RULES, r.Path),
 			}
 		}
 		return nil

--- a/sourcetool/pkg/sourcetool/models/models.go
+++ b/sourcetool/pkg/sourcetool/models/models.go
@@ -3,6 +3,7 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -13,6 +14,8 @@ import (
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/provenance"
 	"github.com/slsa-framework/slsa-source-poc/sourcetool/pkg/slsa"
 )
+
+var ErrProtectionAlreadyInPlace = errors.New("controls already in place in the repository")
 
 // AttestationStorageReader abstracts an attestation storage system where
 // sourcetool can read VSAs and provenance attestations.
@@ -44,6 +47,7 @@ const (
 	CONFIG_POLICY         ControlConfiguration = "CONFIG_POLICY"
 	CONFIG_GEN_PROVENANCE ControlConfiguration = "CONFIG_GEN_PROVENANCE"
 	CONFIG_BRANCH_RULES   ControlConfiguration = "CONFIG_BRANCH_RULES"
+	CONFIG_TAG_RULES      ControlConfiguration = "CONFIG_TAG_RULES"
 )
 
 type Commit struct {

--- a/sourcetool/pkg/sourcetool/tool.go
+++ b/sourcetool/pkg/sourcetool/tool.go
@@ -20,7 +20,7 @@ import (
 )
 
 var ControlConfigurations = []models.ControlConfiguration{
-	models.CONFIG_POLICY, models.CONFIG_GEN_PROVENANCE, models.CONFIG_BRANCH_RULES,
+	models.CONFIG_POLICY, models.CONFIG_GEN_PROVENANCE, models.CONFIG_BRANCH_RULES, models.CONFIG_TAG_RULES,
 }
 
 // New initializes a new source tool instance.


### PR DESCRIPTION
This PR adds the missing tag protections control to `sourcetool setup`. We were missing the ruleset automation and support int the sourcetool package. This adds all the missing parts:

```
> sourcetool setup controls  --help

sourcetool setup controls configure a repository for SLSA source

The setup controls subcommand configures the specified SLSA security
controls in a repository. As opposed to "setup repo", this subcommand lets you
configure each security control individually.

To use this subcommand you need to export a GitHub token as an environment
variable called GITHUB_TOKEN. To configure the branch rules, the token needs
admin permissions on the repo. For the other configuration it is only required
as an identity source.

The values for --config are as follows:

CONFIG_BRANCH_RULES
Configures push and delete branch protection in the repository, required to reach
SLSA source level 2+. 

CONFIG_TAG_RULES
Configures udpate, push and delete protection for all tags in the repository,
this is required to reach SLSA source level 2+. 

CONFIG_GEN_PROVENANCE
Opens a pull request in the repository to add the provenance generation workflow
after every push. 

CONFIG_POLICY
Opens a pull request on the SLSA policy repository to check in a SLSA Source 
policy for the repository.

Setting up repository forks

The controls that open pull requests require that you have a fork of the
repositories. Make sure you have a fork of the SLSA source policy repo and
a fork of the repository you want to protect.

Usage:
  sourcetool setup controls owner/repo --config=CONTROL1 --config=CONTROL2 [flags]

Flags:
      --branch string      name of the branch
      --config strings     control to configure [CONFIG_POLICY CONFIG_GEN_PROVENANCE CONFIG_BRANCH_RULES CONFIG_TAG_RULES]
      --enforce            create enforcement rules
  -h, --help               help for controls
      --interactive        confirm before performing changes (default true)
      --owner string       user or oganization that owns the repo
      --repo string        name of the repository
      --user-fork string   GitHub organization to look for forks of repos (for pull requests)

Global Flags:
  -c, --commit string            commit digest (sha1)
      --expected_issuer string   The expected issuer of the attestation signer certificate
      --expected_san string      The expected SAN string in the attestation signer certificate
      --github_token string      the github token to use for auth
      --tag string               The tag within the repository

```