### PR TITLE
Support tag control automation in sourcetool setup repo 

### DIFF
--- a/sourcetool/internal/cmd/setup.go
+++ b/sourcetool/internal/cmd/setup.go
@@ -180,6 +180,13 @@ sourcetool is about to perform the following actions on your behalf:
 				return fmt.Errorf("onboarding repo: %w", err)
 			}
 
+			fmt.Println()
+			fmt.Println(w("✅ Controls have been configured successfully."))
+			fmt.Println()
+			fmt.Printf("Please run %s\n", w2("sourcetool status "+opts.GetRepository().Path))
+			fmt.Println("to check the status of the new controls and for the next steps.")
+			fmt.Println()
+
 			return nil
 		},
 	}

--- a/sourcetool/internal/cmd/status.go
+++ b/sourcetool/internal/cmd/status.go
@@ -171,8 +171,8 @@ sourcetool status myorg/myrepo@mybranch
 					continue
 				}
 
-				// Suggest creating the policy but only on the higher levels
-				if status.Name == slsa.PolicyAvailable && toplevel == slsa.SlsaSourceLevel1 {
+				// Suggest creating the policy but only when reaching SLSA3+
+				if status.Name == slsa.PolicyAvailable && !slsa.IsLevelHigherOrEqualTo(toplevel, slsa.SlsaSourceLevel3) {
 					continue
 				}
 

--- a/sourcetool/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
+++ b/sourcetool/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
@@ -139,10 +139,11 @@ type FakeToolImplementation struct {
 		result1 *models.PullRequest
 		result2 error
 	}
-	VerifyOptionsForFullOnboardStub        func(*options.Options) error
+	VerifyOptionsForFullOnboardStub        func(*auth.Authenticator, *options.Options) error
 	verifyOptionsForFullOnboardMutex       sync.RWMutex
 	verifyOptionsForFullOnboardArgsForCall []struct {
-		arg1 *options.Options
+		arg1 *auth.Authenticator
+		arg2 *options.Options
 	}
 	verifyOptionsForFullOnboardReturns struct {
 		result1 error
@@ -746,18 +747,19 @@ func (fake *FakeToolImplementation) SearchPullRequestReturnsOnCall(i int, result
 	}{result1, result2}
 }
 
-func (fake *FakeToolImplementation) VerifyOptionsForFullOnboard(arg1 *options.Options) error {
+func (fake *FakeToolImplementation) VerifyOptionsForFullOnboard(arg1 *auth.Authenticator, arg2 *options.Options) error {
 	fake.verifyOptionsForFullOnboardMutex.Lock()
 	ret, specificReturn := fake.verifyOptionsForFullOnboardReturnsOnCall[len(fake.verifyOptionsForFullOnboardArgsForCall)]
 	fake.verifyOptionsForFullOnboardArgsForCall = append(fake.verifyOptionsForFullOnboardArgsForCall, struct {
-		arg1 *options.Options
-	}{arg1})
+		arg1 *auth.Authenticator
+		arg2 *options.Options
+	}{arg1, arg2})
 	stub := fake.VerifyOptionsForFullOnboardStub
 	fakeReturns := fake.verifyOptionsForFullOnboardReturns
-	fake.recordInvocation("VerifyOptionsForFullOnboard", []interface{}{arg1})
+	fake.recordInvocation("VerifyOptionsForFullOnboard", []interface{}{arg1, arg2})
 	fake.verifyOptionsForFullOnboardMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -771,17 +773,17 @@ func (fake *FakeToolImplementation) VerifyOptionsForFullOnboardCallCount() int {
 	return len(fake.verifyOptionsForFullOnboardArgsForCall)
 }
 
-func (fake *FakeToolImplementation) VerifyOptionsForFullOnboardCalls(stub func(*options.Options) error) {
+func (fake *FakeToolImplementation) VerifyOptionsForFullOnboardCalls(stub func(*auth.Authenticator, *options.Options) error) {
 	fake.verifyOptionsForFullOnboardMutex.Lock()
 	defer fake.verifyOptionsForFullOnboardMutex.Unlock()
 	fake.VerifyOptionsForFullOnboardStub = stub
 }
 
-func (fake *FakeToolImplementation) VerifyOptionsForFullOnboardArgsForCall(i int) *options.Options {
+func (fake *FakeToolImplementation) VerifyOptionsForFullOnboardArgsForCall(i int) (*auth.Authenticator, *options.Options) {
 	fake.verifyOptionsForFullOnboardMutex.RLock()
 	defer fake.verifyOptionsForFullOnboardMutex.RUnlock()
 	argsForCall := fake.verifyOptionsForFullOnboardArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeToolImplementation) VerifyOptionsForFullOnboardReturns(result1 error) {

--- a/sourcetool/pkg/sourcetool/tool.go
+++ b/sourcetool/pkg/sourcetool/tool.go
@@ -80,26 +80,16 @@ func (t *Tool) OnboardRepository(repo *models.Repository, branches []*models.Bra
 		return fmt.Errorf("getting VCS backend: %w", err)
 	}
 
-	if err := t.impl.CheckForks(&t.Options); err != nil {
-		return fmt.Errorf("checking repository forks: %w", err)
-	}
-
-	if err := t.impl.VerifyOptionsForFullOnboard(&t.Options); err != nil {
+	if err := t.impl.VerifyOptionsForFullOnboard(t.Authenticator, &t.Options); err != nil {
 		return fmt.Errorf("verifying options: %w", err)
 	}
 
 	if err = backend.ConfigureControls(
 		repo, branches, []models.ControlConfiguration{
-			models.CONFIG_BRANCH_RULES, models.CONFIG_GEN_PROVENANCE,
+			models.CONFIG_BRANCH_RULES, models.CONFIG_GEN_PROVENANCE, models.CONFIG_TAG_RULES,
 		},
 	); err != nil {
 		return fmt.Errorf("configuring controls: %w", err)
-	}
-
-	// TODO(puerco): Compute the policy here
-	_, err = t.impl.CreatePolicyPR(t.Authenticator, &t.Options, repo, nil)
-	if err != nil {
-		return fmt.Errorf("opening the policy pull request: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds cohesion to the on-shot onboarding flow and recommended steps and adds support for the tag control automation when configuring all the repository controls at once. 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>