### PR TITLE
Create fork on user's account if not found

### DIFF
--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -307,7 +307,8 @@ a fork of the repository you want to protect.
 			// Create a new sourcetool object
 			srctool, err := sourcetool.New(
 				sourcetool.WithAuthenticator(authenticator),
-				sourcetool.WithPolicyRepo(opts.policyRepo),
+				// Uncomment when we support other policy repo
+				// sourcetool.WithPolicyRepo(opts.policyRepo),
 				sourcetool.WithUserForkOrg(opts.userForkOrg),
 				sourcetool.WithEnforce(opts.enforce),
 			)
@@ -316,8 +317,16 @@ a fork of the repository you want to protect.
 			}
 			cs := []models.ControlConfiguration{}
 			if opts.interactive {
-				fmt.Println("\nsourcetool is about to perform the following actions on your behalf:")
-				fmt.Println("")
+				// Check if we need the policy fork
+				if slices.Contains(opts.configs, string(models.CONFIG_POLICY)) {
+					if err := ensureOrCreatePolicyFork(srctool); err != nil {
+						return err
+					}
+				}
+
+				fmt.Println()
+				fmt.Println("sourcetool is about to perform the following actions on your behalf:")
+				fmt.Println()
 
 				for _, c := range opts.configs {
 					cs = append(cs, models.ControlConfiguration(c))

--- a/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
+++ b/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
@@ -65,6 +65,20 @@ type FakeToolImplementation struct {
 		result1 *models.PullRequest
 		result2 error
 	}
+	CreateRepositoryForkStub        func(context.Context, *auth.Authenticator, *models.Repository, string) error
+	createRepositoryForkMutex       sync.RWMutex
+	createRepositoryForkArgsForCall []struct {
+		arg1 context.Context
+		arg2 *auth.Authenticator
+		arg3 *models.Repository
+		arg4 string
+	}
+	createRepositoryForkReturns struct {
+		result1 error
+	}
+	createRepositoryForkReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetAttestationReaderStub        func(*models.Repository) (models.AttestationStorageReader, error)
 	getAttestationReaderMutex       sync.RWMutex
 	getAttestationReaderArgsForCall []struct {
@@ -416,6 +430,70 @@ func (fake *FakeToolImplementation) CreatePolicyPRReturnsOnCall(i int, result1 *
 		result1 *models.PullRequest
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeToolImplementation) CreateRepositoryFork(arg1 context.Context, arg2 *auth.Authenticator, arg3 *models.Repository, arg4 string) error {
+	fake.createRepositoryForkMutex.Lock()
+	ret, specificReturn := fake.createRepositoryForkReturnsOnCall[len(fake.createRepositoryForkArgsForCall)]
+	fake.createRepositoryForkArgsForCall = append(fake.createRepositoryForkArgsForCall, struct {
+		arg1 context.Context
+		arg2 *auth.Authenticator
+		arg3 *models.Repository
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.CreateRepositoryForkStub
+	fakeReturns := fake.createRepositoryForkReturns
+	fake.recordInvocation("CreateRepositoryFork", []interface{}{arg1, arg2, arg3, arg4})
+	fake.createRepositoryForkMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeToolImplementation) CreateRepositoryForkCallCount() int {
+	fake.createRepositoryForkMutex.RLock()
+	defer fake.createRepositoryForkMutex.RUnlock()
+	return len(fake.createRepositoryForkArgsForCall)
+}
+
+func (fake *FakeToolImplementation) CreateRepositoryForkCalls(stub func(context.Context, *auth.Authenticator, *models.Repository, string) error) {
+	fake.createRepositoryForkMutex.Lock()
+	defer fake.createRepositoryForkMutex.Unlock()
+	fake.CreateRepositoryForkStub = stub
+}
+
+func (fake *FakeToolImplementation) CreateRepositoryForkArgsForCall(i int) (context.Context, *auth.Authenticator, *models.Repository, string) {
+	fake.createRepositoryForkMutex.RLock()
+	defer fake.createRepositoryForkMutex.RUnlock()
+	argsForCall := fake.createRepositoryForkArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeToolImplementation) CreateRepositoryForkReturns(result1 error) {
+	fake.createRepositoryForkMutex.Lock()
+	defer fake.createRepositoryForkMutex.Unlock()
+	fake.CreateRepositoryForkStub = nil
+	fake.createRepositoryForkReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeToolImplementation) CreateRepositoryForkReturnsOnCall(i int, result1 error) {
+	fake.createRepositoryForkMutex.Lock()
+	defer fake.createRepositoryForkMutex.Unlock()
+	fake.CreateRepositoryForkStub = nil
+	if fake.createRepositoryForkReturnsOnCall == nil {
+		fake.createRepositoryForkReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.createRepositoryForkReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeToolImplementation) GetAttestationReader(arg1 *models.Repository) (models.AttestationStorageReader, error) {


### PR DESCRIPTION
This PR adds a feature to ask a user to create a fork of the policy repository when performing policy operations. If the users does not have a fork of the policy community repo, we will now create it for them:

<img width="806" height="382" alt="image" src="https://github.com/user-attachments/assets/fe59ee5a-fb8b-4a01-8933-d08eaa9e3b16" />

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>