### PR TITLE
Update verifier paths, bridge ID migration

### DIFF
--- a/internal/cmd/checktag.go
+++ b/internal/cmd/checktag.go
@@ -70,7 +70,7 @@ func doCheckTag(args *checkTagOptions) error {
 	pa := attest.NewProvenanceAttestor(ghconnection, verifier)
 	prov, err := pa.CreateTagProvenance(ctx, args.commit, ghcontrol.TagToFullRef(args.tagName), args.actor)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating tag provenance metadata: %w", err)
 	}
 
 	// check p against policy
@@ -78,7 +78,7 @@ func doCheckTag(args *checkTagOptions) error {
 	pe.UseLocalPolicy = args.useLocalPolicy
 	verifiedLevels, policyPath, err := pe.EvaluateTagProv(ctx, args.GetRepository(), prov)
 	if err != nil {
-		return err
+		return fmt.Errorf("evaluating the tag provenance metadata: %w", err)
 	}
 
 	// create vsa

--- a/pkg/attest/verify.go
+++ b/pkg/attest/verify.go
@@ -17,7 +17,7 @@ type VerificationOptions struct {
 // folks should be using (they won't all run from main).
 var DefaultVerifierOptions = VerificationOptions{
 	ExpectedIssuer: "https://token.actions.githubusercontent.com",
-	ExpectedSan:    "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/heads/main",
+	ExpectedSan:    "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/main",
 }
 
 type Verifier interface {

--- a/pkg/attest/verify.go
+++ b/pkg/attest/verify.go
@@ -13,11 +13,16 @@ type VerificationOptions struct {
 	ExpectedSan    string
 }
 
+const (
+	ExpectedIssuer = "https://token.actions.githubusercontent.com"
+	ExpectedSan    = "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/main"
+)
+
 // TODO: Update ExpectedSan to support regex so we can get the branches/tags we really think
 // folks should be using (they won't all run from main).
 var DefaultVerifierOptions = VerificationOptions{
-	ExpectedIssuer: "https://token.actions.githubusercontent.com",
-	ExpectedSan:    "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/main",
+	ExpectedIssuer: ExpectedIssuer,
+	ExpectedSan:    ExpectedSan,
 }
 
 type Verifier interface {

--- a/pkg/attest/verify.go
+++ b/pkg/attest/verify.go
@@ -14,8 +14,19 @@ type VerificationOptions struct {
 }
 
 const (
+	// ExpectedIssuer is the OIDC issuer found in the sigstore bundles
 	ExpectedIssuer = "https://token.actions.githubusercontent.com"
-	ExpectedSan    = "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/main"
+
+	// Expected SAN is the expected identity of the workflow signing the
+	// provenance and VSAs.
+	ExpectedSan = "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/main"
+
+	// OldExpectedSan is the old singer identity before splitting out the actions to their own repo
+	// this constant is part of a compatibility hack that should be reverted once the latests attestations
+	// of the repos are signed with the new identity.
+	//
+	// See https://github.com/slsa-framework/slsa-source-poc/issues/255
+	OldExpectedSan = "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/heads/main"
 )
 
 // TODO: Update ExpectedSan to support regex so we can get the branches/tags we really think

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	VsaPredicateType = "https://slsa.dev/verification_summary/v1"
-	VsaVerifierId    = "https://github.com/slsa-framework/slsa-source-poc"
+	VsaVerifierId    = "https://github.com/slsa-framework/source-actions"
 )
 
 func CreateUnsignedSourceVsa(repoUri, ref, commit string, verifiedLevels slsa.SourceVerifiedLevels, policy string) (string, error) {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	SourcePolicyUri       = "github.com/slsa-framework/slsa-source-poc"
+	SourcePolicyUri       = "github.com/slsa-framework/source-policies"
 	SourcePolicyRepoOwner = "slsa-framework"
 	SourcePolicyRepo      = "source-policies"
 )


### PR DESCRIPTION
This commit fixes the broken tag verification by updating the paths and URIs for the verification IDs to those of the new repos.

This fixes the verification and retrieval of commits using the latest release of sourcetool but would break backwards compatibility with attestations signed with older releases unless...

:warning: **Improtant Note**

This commit includes a compatibility hack in e4e1f804a49531949bc5c7c61b16e99705dcb898 to allow verifying attestations with both the old (this repo) and new (slsa-framework/source-actions) signer identities. This commit should be reverted once all repos are signing with the new workflow.

See this issue for more info: https://github.com/slsa-framework/slsa-source-poc/issues/255

Before updating the [local_attest](https://github.com/slsa-framework/slsa-source-poc/blob/main/.github/workflows/local_attest.yml) this PR needs to go in to support the identity change.

/cc @TomHennen  ^^