### PR TITLE
Run repo workflow template on tag push

### DIFF
--- a/pkg/sourcetool/backends/vcs/github/manage.go
+++ b/pkg/sourcetool/backends/vcs/github/manage.go
@@ -36,6 +36,7 @@ name: SLSA Source
 on:
   push:
     branches: [ %s ]
+    tags: ['**']
 permissions: {}
 
 jobs:


### PR DESCRIPTION
This commit modifies the repository workflow tempalte to run also on tag runs which was missing.

Closes #260