### PR TITLE
Control prechecks, implement fork

### DIFF
--- a/pkg/sourcetool/backends/vcs/github/github.go
+++ b/pkg/sourcetool/backends/vcs/github/github.go
@@ -20,12 +20,18 @@ import (
 func New() *Backend {
 	return &Backend{
 		authenticator: auth.New(),
+		Options:       Options{UseFork: true},
 	}
+}
+
+type Options struct {
+	UseFork bool
 }
 
 // Backend implemets the GitHub sourcetool backend
 type Backend struct {
 	authenticator *auth.Authenticator
+	Options       Options
 }
 
 // getGitHubConnection builds a github connector to a repository

--- a/pkg/sourcetool/implementation.go
+++ b/pkg/sourcetool/implementation.go
@@ -100,7 +100,7 @@ func (impl *defaultToolImplementation) CreatePolicyPR(a *auth.Authenticator, opt
 		return nil, fmt.Errorf("checking policy repository fork: %w", err)
 	}
 
-	// MArshal the policy json
+	// Marshal the policy json
 	policyJson, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshaling policy data: %w", err)

--- a/pkg/sourcetool/models/models.go
+++ b/pkg/sourcetool/models/models.go
@@ -42,7 +42,12 @@ type VcsBackend interface {
 	ControlConfigurationDescr(*Branch, ControlConfiguration) string
 	ConfigureControls(*Repository, []*Branch, []ControlConfiguration) error
 	GetLatestCommit(context.Context, *Repository, *Branch) (*Commit, error)
+	ControlPrecheck(*Repository, []*Branch, ControlConfiguration) (bool, string, ControlPreRemediationFn, error)
 }
+
+// ControlPreRemediation is a function returned by the VCS backends
+// when checking for prerequisites that the user may optionally run
+type ControlPreRemediationFn func() (string, error)
 
 type ControlConfiguration string
 

--- a/pkg/sourcetool/models/modelsfakes/fake_vcs_backend.go
+++ b/pkg/sourcetool/models/modelsfakes/fake_vcs_backend.go
@@ -35,6 +35,25 @@ type FakeVcsBackend struct {
 	controlConfigurationDescrReturnsOnCall map[int]struct {
 		result1 string
 	}
+	ControlPrecheckStub        func(*models.Repository, []*models.Branch, models.ControlConfiguration) (bool, string, models.ControlPreRemediationFn, error)
+	controlPrecheckMutex       sync.RWMutex
+	controlPrecheckArgsForCall []struct {
+		arg1 *models.Repository
+		arg2 []*models.Branch
+		arg3 models.ControlConfiguration
+	}
+	controlPrecheckReturns struct {
+		result1 bool
+		result2 string
+		result3 models.ControlPreRemediationFn
+		result4 error
+	}
+	controlPrecheckReturnsOnCall map[int]struct {
+		result1 bool
+		result2 string
+		result3 models.ControlPreRemediationFn
+		result4 error
+	}
 	GetBranchControlsStub        func(context.Context, *models.Repository, *models.Branch) (*slsa.ControlSetStatus, error)
 	getBranchControlsMutex       sync.RWMutex
 	getBranchControlsArgsForCall []struct {
@@ -232,6 +251,83 @@ func (fake *FakeVcsBackend) ControlConfigurationDescrReturnsOnCall(i int, result
 	fake.controlConfigurationDescrReturnsOnCall[i] = struct {
 		result1 string
 	}{result1}
+}
+
+func (fake *FakeVcsBackend) ControlPrecheck(arg1 *models.Repository, arg2 []*models.Branch, arg3 models.ControlConfiguration) (bool, string, models.ControlPreRemediationFn, error) {
+	var arg2Copy []*models.Branch
+	if arg2 != nil {
+		arg2Copy = make([]*models.Branch, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.controlPrecheckMutex.Lock()
+	ret, specificReturn := fake.controlPrecheckReturnsOnCall[len(fake.controlPrecheckArgsForCall)]
+	fake.controlPrecheckArgsForCall = append(fake.controlPrecheckArgsForCall, struct {
+		arg1 *models.Repository
+		arg2 []*models.Branch
+		arg3 models.ControlConfiguration
+	}{arg1, arg2Copy, arg3})
+	stub := fake.ControlPrecheckStub
+	fakeReturns := fake.controlPrecheckReturns
+	fake.recordInvocation("ControlPrecheck", []interface{}{arg1, arg2Copy, arg3})
+	fake.controlPrecheckMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3, ret.result4
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+}
+
+func (fake *FakeVcsBackend) ControlPrecheckCallCount() int {
+	fake.controlPrecheckMutex.RLock()
+	defer fake.controlPrecheckMutex.RUnlock()
+	return len(fake.controlPrecheckArgsForCall)
+}
+
+func (fake *FakeVcsBackend) ControlPrecheckCalls(stub func(*models.Repository, []*models.Branch, models.ControlConfiguration) (bool, string, models.ControlPreRemediationFn, error)) {
+	fake.controlPrecheckMutex.Lock()
+	defer fake.controlPrecheckMutex.Unlock()
+	fake.ControlPrecheckStub = stub
+}
+
+func (fake *FakeVcsBackend) ControlPrecheckArgsForCall(i int) (*models.Repository, []*models.Branch, models.ControlConfiguration) {
+	fake.controlPrecheckMutex.RLock()
+	defer fake.controlPrecheckMutex.RUnlock()
+	argsForCall := fake.controlPrecheckArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeVcsBackend) ControlPrecheckReturns(result1 bool, result2 string, result3 models.ControlPreRemediationFn, result4 error) {
+	fake.controlPrecheckMutex.Lock()
+	defer fake.controlPrecheckMutex.Unlock()
+	fake.ControlPrecheckStub = nil
+	fake.controlPrecheckReturns = struct {
+		result1 bool
+		result2 string
+		result3 models.ControlPreRemediationFn
+		result4 error
+	}{result1, result2, result3, result4}
+}
+
+func (fake *FakeVcsBackend) ControlPrecheckReturnsOnCall(i int, result1 bool, result2 string, result3 models.ControlPreRemediationFn, result4 error) {
+	fake.controlPrecheckMutex.Lock()
+	defer fake.controlPrecheckMutex.Unlock()
+	fake.ControlPrecheckStub = nil
+	if fake.controlPrecheckReturnsOnCall == nil {
+		fake.controlPrecheckReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 string
+			result3 models.ControlPreRemediationFn
+			result4 error
+		})
+	}
+	fake.controlPrecheckReturnsOnCall[i] = struct {
+		result1 bool
+		result2 string
+		result3 models.ControlPreRemediationFn
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
 func (fake *FakeVcsBackend) GetBranchControls(arg1 context.Context, arg2 *models.Repository, arg3 *models.Branch) (*slsa.ControlSetStatus, error) {

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -263,3 +263,17 @@ func (t *Tool) CreatePolicyRepoFork(ctx context.Context) error {
 	}
 	return nil
 }
+
+// ControlPrecheck performs a prerequisite check before enabling a contrlol
+// Backend may optionally return a remediation function to correct the
+// prerequisite which the CLI can before attempting to enable the control.
+func (t *Tool) ControlPrecheck(
+	r *models.Repository, branches []*models.Branch, config models.ControlConfiguration,
+) (ok bool, remediationMessage string, remediateFn models.ControlPreRemediationFn, err error) {
+	backend, err := t.impl.GetVcsBackend(r)
+	if err != nil {
+		return false, "", nil, fmt.Errorf("getting VCS backend: %w", err)
+	}
+
+	return backend.ControlPrecheck(r, branches, config)
+}


### PR DESCRIPTION
This PR implements a new ControlPrecheck phase on the VCS abstraction.

Before applying the controls, the CLI will do a "preflight" check to see if the controls can be enabled. VCS backends may provide a function to remediate any missing prerequisites. 

These prechecks are now called by the CLI before attempting to enable controls on the VCS system. 

Using this new mechanism the GitHub backend now checks if the user needs a fork of their own repository before attempting to open a pull request. If the fork is required, sourcetool now asks the user if they want to create it and then open the PR:

<img width="988" height="351" alt="image" src="https://github.com/user-attachments/assets/10810862-10ef-497d-aa12-f84cd4956adb" />


Fixes https://github.com/slsa-framework/slsa-source-poc/issues/264
