### PR TITLE
Fix branch name in new policies

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -365,7 +365,7 @@ func computeSlsaLevel(branchPolicy *ProtectedBranch, _ *ProtectedTag, controls s
 	}
 
 	if branchPolicy.GetSince().AsTime().Before(*eligibleSince) {
-		return []slsa.ControlName{}, fmt.Errorf("policy sets target level %s since %v, but it has only been eligible for that level since %v", branchPolicy.GetTargetSlsaSourceLevel(), branchPolicy.GetSince(), eligibleSince)
+		return []slsa.ControlName{}, fmt.Errorf("policy sets target level %s since %v, but it has only been eligible for that level since %v", branchPolicy.GetTargetSlsaSourceLevel(), branchPolicy.GetSince().AsTime(), eligibleSince)
 	}
 
 	return []slsa.ControlName{slsa.ControlName(branchPolicy.GetTargetSlsaSourceLevel())}, nil

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -214,7 +214,7 @@ func (t *Tool) createPolicy(r *models.Repository, branch *models.Branch, control
 		CanonicalRepo: r.GetHttpURL(),
 		ProtectedBranches: []*policy.ProtectedBranch{
 			{
-				Name:                  branch.FullRef(),
+				Name:                  branch.Name,
 				Since:                 timestamppb.New(*eligibleSince),
 				TargetSlsaSourceLevel: string(eligibleLevel),
 			},


### PR DESCRIPTION
This corrects a bug where policies where being created with the full ref in the branch instead of the short name.