### PR TITLE
Don't set the PROVENANCE_AVAILABLE since date to Now()

### DIFF
--- a/pkg/attest/provenance.go
+++ b/pkg/attest/provenance.go
@@ -139,7 +139,14 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 	curProvPred.Controls = controlStatus.Controls
 
 	// At the very least provenance is available starting now. :)
-	curProvPred.AddControl(&provenance.Control{Name: slsa.ProvenanceAvailable.String(), Since: timestamppb.New(curTime)})
+	// ... indeed, but don't set the `since`` date because doing so breaks
+	// checking against policies.
+	// See https://github.com/slsa-framework/slsa-source-poc/issues/272
+	curProvPred.AddControl(
+		&provenance.Control{
+			Name: slsa.ProvenanceAvailable.String(),
+		},
+	)
 
 	return addPredToStatement(&curProvPred, provenance.SourceProvPredicateType, commit)
 }


### PR DESCRIPTION
This commit removes the now() date when computing PROVENANCE_AVAILABLE as it always moves the compliance date to the time the latest attestation was generated.

Fixes https://github.com/slsa-framework/slsa-source-poc/issues/271
Related to: https://github.com/slsa-framework/slsa-source-poc/issues/272

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>