### PR TITLE
Add tag protection to policy

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -276,6 +276,16 @@ func (pe *PolicyEvaluator) CreateLocalPolicy(ctx context.Context, repo *models.R
 			},
 		},
 	}
+
+	// If the controls returned
+	controls := slsa.Controls(provPred.GetControls())
+	tagHygiene := controls.GetControl(slsa.TagHygiene)
+	if tagHygiene != nil {
+		p.ProtectedTag = &ProtectedTag{
+			Since:      tagHygiene.GetSince(),
+			TagHygiene: true,
+		}
+	}
 	data, err := json.MarshalIndent(&p, "", "  ")
 	if err != nil {
 		return "", err

--- a/pkg/slsa/slsa_types.go
+++ b/pkg/slsa/slsa_types.go
@@ -189,6 +189,9 @@ type ControlRecommendedAction struct {
 // which are active in the set.
 func (cs *ControlSetStatus) GetActiveControls() *Controls {
 	ret := Controls{}
+	if cs == nil {
+		return &ret
+	}
 	for _, c := range cs.Controls {
 		if c.State == StateActive {
 			ret.AddControl(&provenance.Control{

--- a/pkg/sourcetool/backends/vcs/github/github.go
+++ b/pkg/sourcetool/backends/vcs/github/github.go
@@ -201,7 +201,7 @@ func (b *Backend) ControlConfigurationDescr(branch *models.Branch, config models
 		)
 	case models.CONFIG_TAG_RULES:
 		return fmt.Sprintf(
-			"Enable push/update/delete protection for all tags in %s",
+			"Enable force push/update/delete protection for all tags in %s",
 			repo.Path,
 		)
 	default:

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -220,6 +220,15 @@ func (t *Tool) createPolicy(r *models.Repository, branch *models.Branch, control
 			},
 		},
 	}
+
+	// If the controls returned
+	tagHygiene := controls.GetActiveControls().GetControl(slsa.TagHygiene)
+	if tagHygiene != nil {
+		p.ProtectedTag = &policy.ProtectedTag{
+			Since:      tagHygiene.GetSince(),
+			TagHygiene: true,
+		}
+	}
 	return p, nil
 }
 


### PR DESCRIPTION
This PR modifies the policy generator to add the tag protection entry when it is reported as active. 

If it's not there then the Tag protection struct will not be in the policy JSON.

Sample:

```json
{
  "canonical_repo": "https://github.com/puerco/slsa-source-test.git",
  "protected_branches": [
    {
      "since": "2025-07-28T08:18:16.582Z",
      "name": "main",
      "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3"
    }
  ],
  "protected_tag": {
    "since": "2025-07-28T08:18:16.582Z",
    "tag_hygiene": true
  }
}
``` 

Fixes #274
Fixes #259

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>
