### PR TITLE
Fix bug in PR manager causing double commits

### DIFF
--- a/pkg/repo/clone.go
+++ b/pkg/repo/clone.go
@@ -168,6 +168,7 @@ func (c *Clone) Commit(opts *options.CommitOptions) error {
 			}
 			return err
 		}
+		return nil
 	}
 	return c.puregoCommit(opts)
 }

--- a/pkg/repo/pullrequest.go
+++ b/pkg/repo/pullrequest.go
@@ -107,7 +107,7 @@ func (prm *PullRequestManager) PullRequestFileList(
 	}
 
 	if err := prm.impl.CommitChanges(opts, clone); err != nil {
-		return nil, fmt.Errorf("committing changes to remote: %w", err)
+		return nil, fmt.Errorf("committing changes: %w", err)
 	}
 
 	if err := prm.impl.PushFeatureBranch(&prm.Options, clone); err != nil {


### PR DESCRIPTION
This commit fixes a bug where the pull request manager would double commit when evaluating using git or the go implementation.