### PR TITLE
Suggest policy subcommand

### DIFF
--- a/pkg/sourcetool/implementation.go
+++ b/pkg/sourcetool/implementation.go
@@ -276,7 +276,7 @@ func (impl *defaultToolImplementation) GetPolicyStatus(
 			Message: fmt.Sprintf("Repository policy not found for %s", r.Path),
 			RecommendedAction: &slsa.ControlRecommendedAction{
 				Message: "Create a policy for the repository",
-				Command: fmt.Sprintf("buildtool setup --config=CONFIG_POLICY %s", r.Path),
+				Command: fmt.Sprintf("buildtool policy create %s", r.Path),
 			},
 		}, nil
 	}


### PR DESCRIPTION
This commit modifies the policy control suggestion to direct the user to use the `sourcetool policy create` subcommand instead of `setup control` (which also had a typo).


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>