### PR TITLE
Even SourceTool API context

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -39,4 +39,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.8
+          version: v2.10

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -171,6 +171,7 @@ linters:
     gosec:
       excludes:
         - G304
+        - G704
     nolintlint:
       # Enable to ensure that nolint directives are all used. Default is true.
       allow-unused: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slsa-framework/source-tool
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/carabiner-dev/attestation v0.2.0

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -311,7 +311,7 @@ func displayPolicy(opts repoOptions, pcy *policy.RepoPolicy) error {
 // ensureOrCreatePolicyFork checks the user has a fork of the policy repo.
 // In case they do not, asks to create a fork in their GitHub account.
 func ensureOrCreatePolicyFork(srctool *sourcetool.Tool) error {
-	found, err := srctool.CheckPolicyRepoFork()
+	found, err := srctool.CheckPolicyRepoFork(context.Background())
 	if err != nil {
 		return fmt.Errorf("checking for policy repo fork: %w", err)
 	}

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -158,7 +158,7 @@ Alternatively, to enable each control individually use: sourcetool setup control
 				models.CONFIG_TAG_RULES, models.CONFIG_GEN_PROVENANCE, models.CONFIG_BRANCH_RULES,
 			} {
 				ok, actionDescr, remediateFn, err := srctool.ControlPrecheck(
-					opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cc,
+					cmd.Context(), opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cc,
 				)
 				if err != nil {
 					return fmt.Errorf("checking prerequisites for %s: %w", cc, err)
@@ -217,7 +217,7 @@ sourcetool is about to perform the following actions on your behalf:
 			}
 
 			err = srctool.OnboardRepository(
-				opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()},
+				cmd.Context(), opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()},
 			)
 			if err != nil {
 				return fmt.Errorf("onboarding repo: %w", err)
@@ -371,7 +371,7 @@ a fork of the repository you want to protect.
 
 					// Check the control prerequisites
 					ok, actionDescr, remediateFn, err := srctool.ControlPrecheck(
-						opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cc,
+						cmd.Context(), opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cc,
 					)
 					if err != nil {
 						return fmt.Errorf("checking prerequisites for %s: %w", cc, err)
@@ -426,7 +426,9 @@ a fork of the repository you want to protect.
 				for _, c := range opts.configs {
 					cc := models.ControlConfiguration(c)
 					// Run the prerequisites and run any remediations
-					ok, _, remediateFn, err := srctool.ControlPrecheck(opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cc)
+					ok, _, remediateFn, err := srctool.ControlPrecheck(
+						cmd.Context(), opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cc,
+					)
 					if err != nil {
 						return fmt.Errorf("checking prerequisites for %q: %w", cc, err)
 					}
@@ -441,7 +443,7 @@ a fork of the repository you want to protect.
 				}
 			}
 			err = srctool.ConfigureControls(
-				opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cs,
+				cmd.Context(), opts.GetBranch().Repository, []*models.Branch{opts.GetBranch()}, cs,
 			)
 			if err != nil {
 				// if strings.Contains(err.Error(), models.ErrProtectionAlreadyInPlace.Error()) {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -110,7 +110,7 @@ sourcetool status myorg/myrepo@mybranch
 			}
 
 			// Get the active repository controls
-			controls, err := srctool.GetBranchControls(opts.GetRepository(), opts.GetBranch())
+			controls, err := srctool.GetBranchControls(cmd.Context(), opts.GetRepository(), opts.GetBranch())
 			if err != nil {
 				return fmt.Errorf("fetching active controls: %w", err)
 			}

--- a/pkg/attest/log.go
+++ b/pkg/attest/log.go
@@ -9,5 +9,6 @@ import (
 )
 
 func Debugf(format string, args ...any) {
+	//nolint:gosec // G706 This is feneral purpose logger
 	slog.Debug(fmt.Sprintf(format, args...))
 }

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -54,7 +54,7 @@ type DeviceCodeResponse struct {
 
 // TokenResponse is the data structure returned when exchanging tokens
 type TokenResponse struct {
-	AccessToken string `json:"access_token"`
+	AccessToken string `json:"access_token"` //nolint:gosec // G117 This is the github struct
 	TokenType   string `json:"token_type"`
 	Scope       string `json:"scope"`
 	Error       string `json:"error"`

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -692,12 +692,12 @@ func assertProtectedBranchEquals(t *testing.T, got, expected *ProtectedBranch, i
 
 	if !reflect.DeepEqual(&actualCopy, &expectedCopy) || !sinceMatch {
 		var errorMessage strings.Builder
-		errorMessage.WriteString(fmt.Sprintf("ProtectedBranch structs not equal:\nExpected: %+v\nGot:      %+v", expected, actual))
+		fmt.Fprintf(&errorMessage, "ProtectedBranch structs not equal:\nExpected: %+v\nGot:      %+v", expected, actual)
 		if !sinceMatch {
-			errorMessage.WriteString(fmt.Sprintf("\nSpecifically, 'Since' fields were not equal (Expected.Since: %v, Got.Since: %v)", expected.GetSince(), actual.GetSince()))
+			fmt.Fprintf(&errorMessage, "\nSpecifically, 'Since' fields were not equal (Expected.Since: %v, Got.Since: %v)", expected.GetSince(), actual.GetSince())
 		}
 		if ignoreSince && actual.GetSince().AsTime() != (time.Time{}) { // Add note only if Since was ignored AND original got.Since was not zero
-			errorMessage.WriteString(fmt.Sprintf("\n(Note: 'Since' field was ignored in comparison as requested. Original Expected.Since: %v, Original Got.Since: %v)", expected.GetSince(), actual.GetSince()))
+			fmt.Fprintf(&errorMessage, "\n(Note: 'Since' field was ignored in comparison as requested. Original Expected.Since: %v, Original Got.Since: %v)", expected.GetSince(), actual.GetSince())
 		}
 		t.Error(errorMessage.String())
 	}

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -52,13 +52,14 @@ type Tool struct {
 }
 
 // GetRepoControls returns the controls that are enabled in a repository branch.
-func (t *Tool) GetBranchControls(r *models.Repository, branch *models.Branch) (*slsa.ControlSetStatus, error) {
-	ctx := context.Background()
+func (t *Tool) GetBranchControls(ctx context.Context, r *models.Repository, branch *models.Branch) (*slsa.ControlSetStatus, error) {
 	backend, err := t.impl.GetVcsBackend(r)
 	if err != nil {
 		return nil, fmt.Errorf("getting VCS backend: %w", err)
 	}
 
+	// Get the control status in the branch. Backends are expected to
+	// return the full SLSA Source control catalog
 	controls, err := t.impl.GetBranchControls(ctx, backend, r, branch)
 	if err != nil {
 		return nil, fmt.Errorf("getting branch controls: %w", err)
@@ -77,7 +78,7 @@ func (t *Tool) GetBranchControls(r *models.Repository, branch *models.Branch) (*
 
 // OnboardRepository configures a repository to set up the required controls
 // to meet SLSA Source L3.
-func (t *Tool) OnboardRepository(repo *models.Repository, branches []*models.Branch) error {
+func (t *Tool) OnboardRepository(ctx context.Context, repo *models.Repository, branches []*models.Branch) error {
 	backend, err := t.impl.GetVcsBackend(repo)
 	if err != nil {
 		return fmt.Errorf("getting VCS backend: %w", err)
@@ -99,7 +100,7 @@ func (t *Tool) OnboardRepository(repo *models.Repository, branches []*models.Bra
 }
 
 // ConfigureControls sets up a control in the repo
-func (t *Tool) ConfigureControls(repo *models.Repository, branches []*models.Branch, configs []models.ControlConfiguration) error {
+func (t *Tool) ConfigureControls(ctx context.Context, repo *models.Repository, branches []*models.Branch, configs []models.ControlConfiguration) error {
 	backend, err := t.impl.GetVcsBackend(repo)
 	if err != nil {
 		return fmt.Errorf("getting VCS backend: %w", err)
@@ -112,7 +113,7 @@ func (t *Tool) ConfigureControls(repo *models.Repository, branches []*models.Bra
 		}
 
 		// Build the policy here:
-		pcy, err := t.CreateBranchPolicy(context.Background(), repo, branches)
+		pcy, err := t.CreateBranchPolicy(ctx, repo, branches)
 		if err != nil {
 			return fmt.Errorf("creating policy for: %w", err)
 		}
@@ -135,7 +136,7 @@ func (t *Tool) ControlConfigurationDescr(branch *models.Branch, config models.Co
 	return backend.ControlConfigurationDescr(branch, config)
 }
 
-func (t *Tool) FindPolicyPR(repo *models.Repository) (*models.PullRequest, error) {
+func (t *Tool) FindPolicyPR(ctx context.Context, repo *models.Repository) (*models.PullRequest, error) {
 	policyRepoOwner := policy.SourcePolicyRepoOwner
 	policyRepoRepo := policy.SourcePolicyRepo
 	o, r, ok := strings.Cut(t.Options.PolicyRepo, "/")
@@ -144,7 +145,7 @@ func (t *Tool) FindPolicyPR(repo *models.Repository) (*models.PullRequest, error
 		policyRepoRepo = r
 	}
 
-	pr, err := t.impl.SearchPullRequest(context.Background(), t.Authenticator, &models.Repository{
+	pr, err := t.impl.SearchPullRequest(ctx, t.Authenticator, &models.Repository{
 		Hostname: "github.com",
 		Path:     fmt.Sprintf("%s/%s", policyRepoOwner, policyRepoRepo),
 	}, fmt.Sprintf("Add %s SLSA Source policy file", repo.Path))
@@ -157,7 +158,7 @@ func (t *Tool) FindPolicyPR(repo *models.Repository) (*models.PullRequest, error
 
 // CheckPolicyRepoFork checks that the logged in user has a fork
 // of the configured policy repo.
-func (t *Tool) CheckPolicyRepoFork() (bool, error) {
+func (t *Tool) CheckPolicyRepoFork(_ context.Context) (bool, error) {
 	if err := t.impl.CheckPolicyFork(&t.Options); err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
 			return false, nil
@@ -277,7 +278,7 @@ func (t *Tool) CreatePolicyRepoFork(ctx context.Context) error {
 // Backend may optionally return a remediation function to correct the
 // prerequisite which the CLI can before attempting to enable the control.
 func (t *Tool) ControlPrecheck(
-	r *models.Repository, branches []*models.Branch, config models.ControlConfiguration,
+	_ context.Context, r *models.Repository, branches []*models.Branch, config models.ControlConfiguration,
 ) (ok bool, remediationMessage string, remediateFn models.ControlPreRemediationFn, err error) {
 	backend, err := t.impl.GetVcsBackend(r)
 	if err != nil {

--- a/pkg/sourcetool/tool_test.go
+++ b/pkg/sourcetool/tool_test.go
@@ -35,7 +35,7 @@ func TestGetBranchControls(t *testing.T) {
 		tool := &Tool{
 			impl: i,
 		}
-		res, err := tool.GetBranchControls(&models.Repository{}, &models.Branch{})
+		res, err := tool.GetBranchControls(t.Context(), &models.Repository{}, &models.Branch{})
 		require.NotNil(t, res)
 		// This always has one more as we add the synyhetic policy check
 		require.Len(t, res.Controls, 2)
@@ -48,7 +48,7 @@ func TestGetBranchControls(t *testing.T) {
 		tool := &Tool{
 			impl: i,
 		}
-		_, err := tool.GetBranchControls(&models.Repository{}, &models.Branch{})
+		_, err := tool.GetBranchControls(t.Context(), &models.Repository{}, &models.Branch{})
 		require.Error(t, err)
 	})
 }
@@ -121,7 +121,7 @@ func TestConfigureControls(t *testing.T) {
 				impl: i,
 			}
 
-			err := tool.ConfigureControls(&models.Repository{}, []*models.Branch{{}}, tc.controls)
+			err := tool.ConfigureControls(t.Context(), &models.Repository{}, []*models.Branch{{}}, tc.controls)
 			if tc.mustErr {
 				require.Error(t, err)
 				return
@@ -195,7 +195,7 @@ func TestFindPolicyPR(t *testing.T) {
 				impl: tc.prepare(t),
 			}
 
-			prd, err := tool.FindPolicyPR(&models.Repository{})
+			prd, err := tool.FindPolicyPR(t.Context(), &models.Repository{})
 			if tc.mustErr {
 				require.Error(t, err)
 				return
@@ -241,7 +241,7 @@ func TestCheckPolicyFork(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tool := Tool{impl: tc.prepare(t)}
-			found, err := tool.CheckPolicyRepoFork()
+			found, err := tool.CheckPolicyRepoFork(t.Context())
 			if tc.mustErr {
 				require.Error(t, err)
 				return
@@ -335,7 +335,7 @@ func TestOnboardRepository(t *testing.T) {
 			tool, err := New()
 			require.NoError(t, err)
 			tool.impl = impl
-			err = tool.OnboardRepository(&models.Repository{Path: "example/repo"}, []*models.Branch{{Name: "main"}})
+			err = tool.OnboardRepository(t.Context(), &models.Repository{Path: "example/repo"}, []*models.Branch{{Name: "main"}})
 			if tt.mustErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
This commit modifies the sourcetool api to make all functions take a context. As we are preparing for third party backend, we need to ensure tools can get the tools context if they need it.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>
