### PR TITLE
Update CI jobs, versions an run tests on matrix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,13 +23,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      all:
-        update-types:
-          - "minor"
-          - "patch"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -22,6 +22,10 @@ jobs:
       previous: ${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: carabiner-dev/actions/go/versions@7d7c2b1154a01df68e3fc4f12d07fd148a302a94 # v1.1.4
         id: go-versions
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: carabiner-dev/actions/go/versions@7d7c2b1154a01df68e3fc4f12d07fd148a302a94 # v1.1.4
         id: go-versions
 
-  test:
+  unit-test:
     needs: go-versions
     runs-on: ubuntu-latest
 
@@ -58,6 +58,12 @@ jobs:
       - name: Run Go tests
         run: |
           go test -v ./...
+
+  test:
+    needs: [unit-test, verify]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All tests passed"
 
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -23,13 +23,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Extract version of Go to use
-        run: echo "GOVERSION=$(awk -F'[:@]' '/FROM golang/{print $2; exit}' Dockerfile)" >> $GITHUB_ENV
+      - uses: carabiner-dev/actions/go/versions@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
+        id: go-versions
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ steps.go-versions.outputs.latest }}
           check-latest: true
           cache: false
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -11,7 +11,51 @@ on:
 permissions: {}
 
 jobs:
+  go-versions:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      latest: ${{ steps.go-versions.outputs.GO_VERSION_STABLE }}
+      previous: ${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}
+
+    steps:
+      - uses: carabiner-dev/actions/go/versions@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
+        id: go-versions
+
   test:
+    needs: go-versions
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    strategy:
+      matrix:
+        go-version:
+          - ${{ needs.go-versions.outputs.latest }}
+          - ${{ needs.go-versions.outputs.previous }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache: false
+
+      - name: Run Go tests
+        run: |
+          go test -v ./...
+
+  verify:
     runs-on: ubuntu-latest
 
     permissions:
@@ -29,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ steps.go-versions.outputs.latest }}
+          go-version: ${{ steps.go-versions.outputs.GO_VERSION_STABLE }}
           check-latest: true
           cache: false
 
@@ -39,15 +83,11 @@ jobs:
       - name: Setup protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # @v3.0.0
 
-      - name: Run Go tests
-        run: |
-          go test -v ./...
-
       - name: Check generated fakes
         run: |
           hack/verify-fakes.sh
 
-      - name: Check protobuf generated codew
+      - name: Check protobuf generated code
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           hack/verify-protos.sh

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -22,7 +22,7 @@ jobs:
       previous: ${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}
 
     steps:
-      - uses: carabiner-dev/actions/go/versions@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
+      - uses: carabiner-dev/actions/go/versions@7d7c2b1154a01df68e3fc4f12d07fd148a302a94 # v1.1.4
         id: go-versions
 
   test:
@@ -67,7 +67,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: carabiner-dev/actions/go/versions@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
+      - uses: carabiner-dev/actions/go/versions@7d7c2b1154a01df68e3fc4f12d07fd148a302a94 # v1.1.4
         id: go-versions
 
       - name: Set up Go

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ steps.go-versions.outputs.latest }}
+          go-version: ${{ steps.go-versions.outputs.GO_VERSION_STABLE }}
           check-latest: true
           cache: false
 

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: carabiner-dev/actions/go/versions@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
+      - uses: carabiner-dev/actions/go/versions@7d7c2b1154a01df68e3fc4f12d07fd148a302a94 # v1.1.4
         id: go-versions
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,12 +24,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Extract version of Go to use
-        run: echo "GOVERSION=$(awk -F'[:@]' '/FROM golang/{print $2; exit}' Dockerfile)" >> $GITHUB_ENV
+      - uses: carabiner-dev/actions/go/versions@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
+        id: go-versions
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ steps.go-versions.outputs.latest }}
           check-latest: true
           cache: false
 
@@ -39,4 +39,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.10
+          version: v2.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: Setup bnd
-        uses: carabiner-dev/actions/install/bnd@HEAD
+        uses: carabiner-dev/actions/install/bnd@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
 
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,20 +30,15 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Extract version of Go to use
-        run: echo "GOVERSION=$(awk -F'[:@]' '/FROM golang/{print $2; exit}' Dockerfile)" >> $GITHUB_ENV
-
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
       - name: Install tejolote
         uses: kubernetes-sigs/release-actions/setup-tejolote@8af7b2a5596dff526de9db59b2c4b8457e9f52a1 # v0.4.0
-        with:
-          tejolote-release: "0.4.1"
-
+        
       - name: Set tag output
         id: tag
         run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: Setup bnd
-        uses: carabiner-dev/actions/install/bnd@440c76def32d40be101b68d1f6a6b284b79aa74c # v1.1.2
+        uses: carabiner-dev/actions/install/bnd@7d7c2b1154a01df68e3fc4f12d07fd148a302a94 # v1.1.4
 
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-# This is used to we scrap the go version and use in CI to get the latest go version
-# and we use dependabot to keep the go version up to date
-FROM golang:1.25.8


### PR DESCRIPTION
This pull request updates the CI workflows to improve Go version management and removes Docker-related configuration that is no longer needed. The main changes include switching to a shared action for determining Go versions in CI, updating some action versions, and cleaning up obsolete Docker and Dependabot settings.

**CI/CD improvements:**

* Updated all workflows (`go-test.yml`, `golangci-lint.yaml`, `release.yaml`) to use the `carabiner-dev/actions/go/versions` action for determining Go versions, replacing manual extraction from the `Dockerfile`. This ensures consistency and easier updates across workflows. [[1]](diffhunk://#diff-cb63f6037602c7aa1591d3dca2a9c1870ef95ac59f67aaa90dd9cd1163e20898R14-R58) [[2]](diffhunk://#diff-cb63f6037602c7aa1591d3dca2a9c1870ef95ac59f67aaa90dd9cd1163e20898L26-R76) [[3]](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0L27-R32)
* In `go-test.yml`, added a matrix strategy to run tests against both the latest and previous Go versions, improving test coverage across Go releases.
* Updated the version of `golangci-lint` used in CI from v2.10 to v2.11 for improved linting and new features.
* Updated action pinning for better security and reproducibility, including specifying exact commit SHAs for all GitHub Actions.

**Cleanup and configuration changes:**

* Removed the `Dockerfile` and associated configuration from Dependabot and CI, as Go version management is now handled directly in the workflows. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-L3) [[2]](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cL26-L35)