### PR TITLE
Fix two incompatibilities in flags

### DIFF
--- a/internal/cmd/checktag.go
+++ b/internal/cmd/checktag.go
@@ -44,6 +44,10 @@ func (cto *checkTagOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&cto.outputUnsignedBundle, "output_unsigned_bundle", "", "The path to write a bundle of unsigned attestations.")
 	cmd.PersistentFlags().StringVar(&cto.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
 	cmd.PersistentFlags().Uint8Var(&cto.vsaRetries, "retries", 3, "Number of times to retry fetching the commit's VSA")
+
+	// Hidden alias for backwards compatibility with the old --tag_name flag.
+	cmd.PersistentFlags().StringVar(&cto.tag, "tag_name", "", "Git tag within the repository")
+	cmd.PersistentFlags().MarkHidden("tag_name") //nolint:errcheck,gosec
 }
 
 func addCheckTag(parentCmd *cobra.Command) {

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -243,7 +243,6 @@ func (to *tagOptions) AddFlags(cmd *cobra.Command) {
 }
 
 type revisionOpts struct {
-	repoOptions
 	tagOptions
 	branchOptions
 	commitOptions


### PR DESCRIPTION
This PR addresses two compatibility issues with the recent sourcetool refactor: 

- Adds `--tag_name` as a hidden alias in `checktag` as the flag was renamed to `--tag` to even it with the other subcommands
- Corrects a double embed that was causing the repo owner to be lost when specified as a flag


Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>