### PR TITLE
Fix the slsa source loop of doom

### DIFF
--- a/internal/cmd/checklevel.go
+++ b/internal/cmd/checklevel.go
@@ -93,19 +93,26 @@ This is meant to be run within the corresponding GitHub Actions workflow.`,
 
 			pe := policy.NewPolicyEvaluator()
 			pe.UseLocalPolicy = opts.useLocalPolicy
-			verifiedLevels, policyPath, err := pe.EvaluateControl(cmd.Context(), opts.GetRepository(), opts.GetBranch(), controlStatus)
+			result, err := pe.EvaluateControl(cmd.Context(), opts.GetRepository(), opts.GetBranch(), controlStatus)
 			if err != nil {
 				return err
 			}
-			for _, level := range verifiedLevels {
+			for _, level := range result.VerifiedLevels {
 				if slsa.IsSlsaSourceLevel(level) {
 					fmt.Print(level)
 					break
 				}
 			}
 
+			// The achieved level can be below the policy target, surface it as a
+			// warning here (checklevel only reports, it does not gate on it).
+			if result.Shortfall != nil {
+				fmt.Fprintf(os.Stderr, "\nwarning: policy target level %s not met; achieved %s: %s\n",
+					result.Shortfall.TargetLevel, result.Shortfall.AchievedLevel, result.Shortfall.Reason)
+			}
+
 			unsignedVsa, err := attest.CreateUnsignedSourceVsa(
-				opts.GetBranch(), opts.GetCommit(), verifiedLevels, policyPath,
+				opts.GetBranch(), opts.GetCommit(), result.VerifiedLevels, result.PolicyPath,
 			)
 			if err != nil {
 				return err

--- a/internal/cmd/checklevelprov.go
+++ b/internal/cmd/checklevelprov.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -60,6 +61,7 @@ type checkLevelProvOpts struct {
 	outputUnsignedBundle string
 	outputSignedBundle   string
 	useLocalPolicy       string
+	silentDowngrade      bool
 }
 
 func (clp *checkLevelProvOpts) Validate() error {
@@ -78,6 +80,7 @@ func (clp *checkLevelProvOpts) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&clp.outputUnsignedBundle, "output_unsigned_bundle", "", "The path to write a bundle of unsigned attestations.")
 	cmd.PersistentFlags().StringVar(&clp.outputSignedBundle, "output_signed_bundle", "", "The path to write a bundle of signed attestations.")
 	cmd.PersistentFlags().StringVar(&clp.useLocalPolicy, "use_local_policy", "", "UNSAFE: Use the policy at this local path instead of the official one.")
+	cmd.PersistentFlags().BoolVar(&clp.silentDowngrade, "silent-downgrade", false, "Exit 0 when the SLSA level is below the policy target (still attests).")
 }
 
 func addCheckLevelProv(parentCmd *cobra.Command) {
@@ -162,7 +165,7 @@ and pushed to its remote (--push=note).
 			}
 
 			// Attest the commit passing the options
-			verifiedLevels, err := srctool.AttestRevision(
+			result, err := srctool.AttestRevision(
 				cmd.Context(), opts.GetBranch(), opts.GetRevision(),
 				sourcetool.WithLocalPolicy(opts.useLocalPolicy),
 				sourcetool.WithOutputPath(outputPath),
@@ -174,7 +177,24 @@ and pushed to its remote (--push=note).
 				return fmt.Errorf("attesting commit: %w", err)
 			}
 
-			fmt.Print(verifiedLevels.Levels())
+			fmt.Print(result.VerifiedLevels.Levels())
+
+			// The attestations are generated (and optionally pushed) regardless
+			// of the policy outcome. If the achieved level is below the policy
+			// target return exit code 2 or just a warning when --silent-downgrade
+			// is set.
+			if result.Shortfall != nil {
+				msg := fmt.Sprintf(
+					"policy target level %s not met; achieved %s: %s",
+					result.Shortfall.TargetLevel, result.Shortfall.AchievedLevel, result.Shortfall.Reason,
+				)
+				if opts.silentDowngrade {
+					fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
+					return nil
+				}
+				return &exitError{code: 2, err: errors.New(msg)}
+			}
+
 			return nil
 		},
 	}

--- a/internal/cmd/checktag.go
+++ b/internal/cmd/checktag.go
@@ -126,7 +126,7 @@ func addCheckTag(parentCmd *cobra.Command) {
 			}
 
 			// Attest the commit passing the options
-			verifiedLevels, err := srctool.AttestRevision(
+			result, err := srctool.AttestRevision(
 				cmd.Context(), opts.GetBranch(), opts.GetRevision(),
 				sourcetool.WithLocalPolicy(opts.useLocalPolicy),
 				sourcetool.WithOutputPath(outputPath),
@@ -138,7 +138,7 @@ func addCheckTag(parentCmd *cobra.Command) {
 				return fmt.Errorf("attesting commit: %w", err)
 			}
 
-			fmt.Print(verifiedLevels.Levels())
+			fmt.Print(result.VerifiedLevels.Levels())
 			return nil
 		},
 	}

--- a/internal/cmd/exiterror_test.go
+++ b/internal/cmd/exiterror_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright 2026 The SLSA Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestExitErrorErrorAndUnwrap(t *testing.T) {
+	wrapped := errors.New("policy target level SLSA_SOURCE_LEVEL_3 not met")
+	ee := &exitError{code: 2, err: wrapped}
+
+	if ee.Error() != wrapped.Error() {
+		t.Errorf("Error() = %q, want %q", ee.Error(), wrapped.Error())
+	}
+	if !errors.Is(ee, wrapped) {
+		t.Errorf("errors.Is(exitError, wrapped) = false, want true (Unwrap should expose the wrapped error)")
+	}
+}
+
+func TestExitErrorExtraction(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		err       error
+		wantMatch bool
+		wantCode  int
+	}{
+		{
+			name:      "direct exit error",
+			err:       &exitError{code: 2, err: errors.New("shortfall")},
+			wantMatch: true,
+			wantCode:  2,
+		},
+		{
+			name:      "wrapped exit error",
+			err:       fmt.Errorf("attesting commit: %w", &exitError{code: 2, err: errors.New("shortfall")}),
+			wantMatch: true,
+			wantCode:  2,
+		},
+		{
+			name:      "plain error falls through",
+			err:       errors.New("boom"),
+			wantMatch: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var ee *exitError
+			gotMatch := errors.As(tt.err, &ee)
+			if gotMatch != tt.wantMatch {
+				t.Fatalf("errors.As() = %v, want %v", gotMatch, tt.wantMatch)
+			}
+			if gotMatch && ee.code != tt.wantCode {
+				t.Errorf("exitError.code = %d, want %d", ee.code, tt.wantCode)
+			}
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -26,11 +26,23 @@ var githubToken string
 // 	return attest.NewBndVerifier(options)
 // }
 
+// exitError wraps an error together with an exit code so commands can
+// signal other failuresdistinct from a generic failure (exit 1).
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+func (e *exitError) Unwrap() error { return e.err }
+
 func buildRootCommand() *cobra.Command {
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd := &cobra.Command{
-		Use:   "sourcetool",
-		Short: "A tool to manage SLSA Source in code repositories",
+		Use:           "sourcetool",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "A tool to manage SLSA Source in code repositories",
 		Long: `
 SLSA sourcetool: Manage SLSA Source controls and data
 
@@ -89,10 +101,21 @@ controls and much more.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	rootCmd := buildRootCommand()
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Error: %v\n", err)
-		os.Exit(1)
+	err := rootCmd.Execute()
+	if err == nil {
+		return
 	}
+
+	// Subcommands may send a specific exit code by returning an *exitError.
+	// Everything else is a generic failure (exit 1).
+	var ee *exitError
+	if errors.As(err, &ee) {
+		fmt.Println(ee.Error())
+		os.Exit(ee.code)
+	}
+
+	fmt.Printf("Error: %v\n", err)
+	os.Exit(1)
 }
 
 func CheckAuth() (*auth.Authenticator, error) {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -370,33 +370,94 @@ func ComputeEligibleSince(controls *slsa.ControlSet, level slsa.SlsaSourceLevel)
 // Every function that determines properties to include in the result & VSA implements this interface.
 type computePolicyResult func(*ProtectedBranch, *ProtectedTag, *slsa.ControlSet) ([]slsa.ControlName, error)
 
-func computeSlsaLevel(branchPolicy *ProtectedBranch, _ *ProtectedTag, controls *slsa.ControlSet) ([]slsa.ControlName, error) {
+// PolicyShortfall captures why a branch achieves a SLSA source level lower tahn
+// the one its policy targets.
+// It's meant to be an informational payload, not an error.
+type PolicyShortfall struct {
+	TargetLevel   slsa.SlsaSourceLevel
+	AchievedLevel slsa.SlsaSourceLevel
+	Reason        string
+}
+
+// EvaluationResult is the outcome of evaluating a branch or tag against its policy.
+type EvaluationResult struct {
+	VerifiedLevels slsa.SourceVerifiedLevels
+	PolicyPath     string
+	// Shortfall is non-nil when the achieved SLSA source level is below the
+	// policy's target level.
+	Shortfall *PolicyShortfall
+}
+
+// computeAchievableSlsaLevel determines the highest SLSA source level the controls
+// satisfy. When the achieved level is below the policy target it also returns a
+// PolicyShortfall describing the gap.
+//
+// Unlike a hard policy failure, a level below target is not an error. We want to
+// always generate provenance at the level achieved and surface the gap
+// so that the chain of provenance is never broken.
+func computeAchievableSlsaLevel(branchPolicy *ProtectedBranch, controls *slsa.ControlSet) (slsa.SlsaSourceLevel, *PolicyShortfall) {
+	target := slsa.SlsaSourceLevel(branchPolicy.GetTargetSlsaSourceLevel())
 	eligibleLevel := ComputeEligibleSlsaLevel(controls)
 
-	if !slsa.IsLevelHigherOrEqualTo(eligibleLevel, slsa.SlsaSourceLevel(branchPolicy.GetTargetSlsaSourceLevel())) {
-		return []slsa.ControlName{}, fmt.Errorf(
+	// Walk down the slsa levels, returning the first that:
+	//    a. does notexceed the target
+	//    b. the controls are eligible for, and
+	//    c. has been continuously eligible since
+	//       at or before the policy's "since" date.
+	for _, level := range []slsa.SlsaSourceLevel{
+		slsa.SlsaSourceLevel4, slsa.SlsaSourceLevel3, slsa.SlsaSourceLevel2,
+	} {
+		// Never stamp a level higher than the policy asks for.
+		if !slsa.IsLevelHigherOrEqualTo(target, level) {
+			continue
+		}
+		if !slsa.IsLevelHigherOrEqualTo(eligibleLevel, level) {
+			continue
+		}
+		eligibleSince, err := ComputeEligibleSince(controls, level)
+		if err != nil || eligibleSince == nil {
+			continue
+		}
+		if branchPolicy.GetSince().AsTime().Before(*eligibleSince) {
+			continue
+		}
+		return level, slsaLevelShortfall(target, level, eligibleLevel, branchPolicy, controls)
+	}
+
+	// Nothing above level 1 is satisfied. L1 is always achievable.
+	return slsa.SlsaSourceLevel1, slsaLevelShortfall(target, slsa.SlsaSourceLevel1, eligibleLevel, branchPolicy, controls)
+}
+
+// slsaLevelShortfall builds the PolicyShortfall when branch is below target
+func slsaLevelShortfall(target, achieved, eligibleLevel slsa.SlsaSourceLevel, branchPolicy *ProtectedBranch, controls *slsa.ControlSet) *PolicyShortfall {
+	if slsa.IsLevelHigherOrEqualTo(achieved, target) {
+		return nil
+	}
+
+	var reason string
+	switch {
+	case !slsa.IsLevelHigherOrEqualTo(eligibleLevel, target):
+		reason = fmt.Sprintf(
 			"policy sets target level %s which requires %v, but branch is only eligible for %s because it only has %v",
-			branchPolicy.GetTargetSlsaSourceLevel(),
-			slsa.GetRequiredControlsForLevel(slsa.SlsaSourceLevel(branchPolicy.GetTargetSlsaSourceLevel())),
-			eligibleLevel,
-			controls.Names(),
+			target, slsa.GetRequiredControlsForLevel(target), eligibleLevel, controls.Names(),
 		)
+	default:
+		eligibleSince, err := ComputeEligibleSince(controls, target)
+		if err != nil || eligibleSince == nil {
+			reason = fmt.Sprintf("policy sets target level %s, but cannot compute when controls made it eligible for that level", target)
+		} else {
+			reason = fmt.Sprintf(
+				"policy sets target level %s since %v, but it has only been eligible for that level since %v",
+				target, branchPolicy.GetSince().AsTime(), *eligibleSince,
+			)
+		}
 	}
 
-	// Check to see when this branch became eligible for the current target level.
-	eligibleSince, err := ComputeEligibleSince(controls, slsa.SlsaSourceLevel(branchPolicy.GetTargetSlsaSourceLevel()))
-	if err != nil {
-		return []slsa.ControlName{}, fmt.Errorf("could not compute eligible since: %w", err)
+	return &PolicyShortfall{
+		TargetLevel:   target,
+		AchievedLevel: achieved,
+		Reason:        reason,
 	}
-	if eligibleSince == nil {
-		return []slsa.ControlName{}, fmt.Errorf("policy sets target level %s, but cannot compute when controls made it eligible for that level", branchPolicy.GetTargetSlsaSourceLevel())
-	}
-
-	if branchPolicy.GetSince().AsTime().Before(*eligibleSince) {
-		return []slsa.ControlName{}, fmt.Errorf("policy sets target level %s since %v, but it has only been eligible for that level since %v", branchPolicy.GetTargetSlsaSourceLevel(), branchPolicy.GetSince().AsTime(), eligibleSince)
-	}
-
-	return []slsa.ControlName{slsa.ControlName(branchPolicy.GetTargetSlsaSourceLevel())}, nil
 }
 
 func computeReviewEnforced(branchPolicy *ProtectedBranch, _ *ProtectedTag, controls *slsa.ControlSet) ([]slsa.ControlName, error) {
@@ -465,26 +526,34 @@ func computeOrgControls(branchPolicy *ProtectedBranch, _ *ProtectedTag, controls
 	return controlNames, nil
 }
 
-// Returns a list of controls to include in the vsa's 'verifiedLevels' field when creating a VSA for a branch.
-func evaluateBranchControls(branchPolicy *ProtectedBranch, tagPolicy *ProtectedTag, controls *slsa.ControlSet) (slsa.SourceVerifiedLevels, error) {
-	policyComputers := []computePolicyResult{
-		computeSlsaLevel,      // Add the SLSA Level to the VSA
+// Returns a list of controls to include in the vsa's 'verifiedLevels' field when
+// creating a VSA for a branch, along with a shortfall if the achieved SLSA source
+// level is below the policy's target.
+func evaluateBranchControls(branchPolicy *ProtectedBranch, tagPolicy *ProtectedTag, controls *slsa.ControlSet) (slsa.SourceVerifiedLevels, *PolicyShortfall, error) {
+	verifiedLevels := slsa.SourceVerifiedLevels{}
+
+	// The SLSA source level is special: a level below the policy target is not a
+	// hard error. We stamp the level actually achieved and report any shortcoming
+	// as a shortfall so the caller can still emit provenance.
+	achievedLevel, shortfall := computeAchievableSlsaLevel(branchPolicy, controls)
+	verifiedLevels = append(verifiedLevels, slsa.ControlName(achievedLevel))
+
+	// A required-but-missing control here is still a hard error.
+	additiveComputers := []computePolicyResult{
 		computeReviewEnforced, // Stamp if reviews are enforced
 		computeTagHygiene,     // Stamp the tag hygiene
 		computeOrgControls,    // Add other organizational controls
 	}
 
-	verifiedLevels := slsa.SourceVerifiedLevels{}
-
-	for _, pc := range policyComputers {
+	for _, pc := range additiveComputers {
 		computedControls, err := pc(branchPolicy, tagPolicy, controls)
 		if err != nil {
-			return slsa.SourceVerifiedLevels{}, fmt.Errorf("error computing branch controls: %w", err)
+			return slsa.SourceVerifiedLevels{}, nil, fmt.Errorf("error computing branch controls: %w", err)
 		}
 		verifiedLevels = append(verifiedLevels, computedControls...)
 	}
 
-	return verifiedLevels, nil
+	return verifiedLevels, shortfall, nil
 }
 
 // Returns a list of controls to include in the vsa's 'verifiedLevels' field when creating a VSA for a tag.
@@ -552,13 +621,14 @@ func NewPolicyEvaluator() *PolicyEvaluator {
 	return eval
 }
 
-// EvaluateControl checks the control against the policy and returns the resulting source level and policy path.
-func (pe *PolicyEvaluator) EvaluateControl(ctx context.Context, repo *models.Repository, branch *models.Branch, controlStatus *slsa.ControlSet) (slsa.SourceVerifiedLevels, string, error) {
-	// We want to check to ensure the repo hasn't enabled/disabled the rules since
+// EvaluateControl checks the control against the policy and returns the resulting
+// source level, policy path and any shortfall if we miss the policy's target.
+func (pe *PolicyEvaluator) EvaluateControl(ctx context.Context, repo *models.Repository, branch *models.Branch, controlStatus *slsa.ControlSet) (*EvaluationResult, error) {
+	// We want to ensure the repo hasn't enabled/disabled the rules since
 	// setting the 'since' field in their policy.
 	rp, policyPath, err := pe.GetPolicy(ctx, repo)
 	if err != nil {
-		return slsa.SourceVerifiedLevels{}, "", err
+		return nil, err
 	}
 
 	branchPolicy := rp.GetBranchPolicy(branch.Name)
@@ -569,27 +639,36 @@ func (pe *PolicyEvaluator) EvaluateControl(ctx context.Context, repo *models.Rep
 
 	if controlStatus.Time.Before(branchPolicy.GetSince().AsTime()) {
 		// This commit was pushed before they had an explicit policy.
-		return slsa.SourceVerifiedLevels{slsa.ControlName(slsa.SlsaSourceLevel1)}, policyPath, nil
+		return &EvaluationResult{
+			VerifiedLevels: slsa.SourceVerifiedLevels{slsa.ControlName(slsa.SlsaSourceLevel1)},
+			PolicyPath:     policyPath,
+		}, nil
 	}
 
-	verifiedLevels, err := evaluateBranchControls(branchPolicy, rp.GetProtectedTag(), controlStatus)
+	verifiedLevels, shortfall, err := evaluateBranchControls(branchPolicy, rp.GetProtectedTag(), controlStatus)
 	if err != nil {
-		return verifiedLevels, policyPath, fmt.Errorf("error evaluating policy %s: %w", policyPath, err)
+		return nil, fmt.Errorf("error evaluating policy %s: %w", policyPath, err)
 	}
 
-	return verifiedLevels, policyPath, nil
+	return &EvaluationResult{
+		VerifiedLevels: verifiedLevels,
+		PolicyPath:     policyPath,
+		Shortfall:      shortfall,
+	}, nil
 }
 
-// Evaluates the provenance against the policy and returns the resulting source level and policy path
-func (pe *PolicyEvaluator) EvaluateSourceProv(ctx context.Context, repo *models.Repository, branch *models.Branch, prov *spb.Statement) (slsa.SourceVerifiedLevels, string, error) {
+// EvaluateSourceProv checks the provenance against the policy and returns the
+// resulting source level, policy path and any shortfall if we miss the the
+// policy's target.
+func (pe *PolicyEvaluator) EvaluateSourceProv(ctx context.Context, repo *models.Repository, branch *models.Branch, prov *spb.Statement) (*EvaluationResult, error) {
 	rp, policyPath, err := pe.GetPolicy(ctx, repo)
 	if err != nil {
-		return slsa.SourceVerifiedLevels{}, "", fmt.Errorf("getting policy: %w", err)
+		return nil, fmt.Errorf("getting policy: %w", err)
 	}
 
 	provPred, err := attest.GetSourceProvPred(prov)
 	if err != nil {
-		return slsa.SourceVerifiedLevels{}, "", err
+		return nil, err
 	}
 
 	branchPolicy := rp.GetBranchPolicy(branch.Name)
@@ -598,32 +677,39 @@ func (pe *PolicyEvaluator) EvaluateSourceProv(ctx context.Context, repo *models.
 		policyPath = "DEFAULT"
 	}
 
-	verifiedLevels, err := evaluateBranchControls(branchPolicy, rp.GetProtectedTag(), slsa.NewControlSetFromProvanenaceControls(provPred.GetControls()))
+	verifiedLevels, shortfall, err := evaluateBranchControls(branchPolicy, rp.GetProtectedTag(), slsa.NewControlSetFromProvanenaceControls(provPred.GetControls()))
 	if err != nil {
-		return slsa.SourceVerifiedLevels{}, policyPath, fmt.Errorf("error evaluating policy %s: %w", policyPath, err)
+		return nil, fmt.Errorf("error evaluating policy %s: %w", policyPath, err)
 	}
 
 	// Looks good!
-	return verifiedLevels, policyPath, nil
+	return &EvaluationResult{
+		VerifiedLevels: verifiedLevels,
+		PolicyPath:     policyPath,
+		Shortfall:      shortfall,
+	}, nil
 }
 
 // Evaluates the provenance against the policy and returns the resulting source level and policy path
-func (pe *PolicyEvaluator) EvaluateTagProv(ctx context.Context, repo *models.Repository, prov *spb.Statement) (slsa.SourceVerifiedLevels, string, error) {
+func (pe *PolicyEvaluator) EvaluateTagProv(ctx context.Context, repo *models.Repository, prov *spb.Statement) (*EvaluationResult, error) {
 	rp, policyPath, err := pe.GetPolicy(ctx, repo)
 	if err != nil {
-		return slsa.SourceVerifiedLevels{}, "", err
+		return nil, err
 	}
 
 	provPred, err := attest.GetTagProvPred(prov)
 	if err != nil {
-		return slsa.SourceVerifiedLevels{}, "", err
+		return nil, err
 	}
 
 	outputVerifiedLevels, err := evaluateTagProv(rp.GetProtectedTag(), provPred)
 	if err != nil {
-		return slsa.SourceVerifiedLevels{}, policyPath, fmt.Errorf("error evaluating policy %s: %w", policyPath, err)
+		return nil, fmt.Errorf("error evaluating policy %s: %w", policyPath, err)
 	}
 
-	// Looks good!
-	return outputVerifiedLevels, policyPath, nil
+	// Looks good! Tag evaluation has no SLSA-level shortfall concept.
+	return &EvaluationResult{
+		VerifiedLevels: outputVerifiedLevels,
+		PolicyPath:     policyPath,
+	}, nil
 }

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -370,8 +370,9 @@ func ComputeEligibleSince(controls *slsa.ControlSet, level slsa.SlsaSourceLevel)
 // Every function that determines properties to include in the result & VSA implements this interface.
 type computePolicyResult func(*ProtectedBranch, *ProtectedTag, *slsa.ControlSet) ([]slsa.ControlName, error)
 
-// PolicyShortfall captures why a branch achieves a SLSA source level lower tahn
+// PolicyShortfall captures why a branch achieves a SLSA source level lower than
 // the one its policy targets.
+//
 // It's meant to be an informational payload, not an error.
 type PolicyShortfall struct {
 	TargetLevel   slsa.SlsaSourceLevel

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -204,19 +204,22 @@ func TestEvaluateSourceProv_Success(t *testing.T) {
 	defer os.Remove(expectedPolicyFilePath) //nolint:errcheck
 	pe := &PolicyEvaluator{UseLocalPolicy: expectedPolicyFilePath}
 
-	verifiedLevels, policyPath, err := pe.EvaluateSourceProv(t.Context(), &models.Repository{
+	result, err := pe.EvaluateSourceProv(t.Context(), &models.Repository{
 		Hostname: "github.com",
 		Path:     "the-canonical-repo",
 	}, &models.Branch{Name: "main"}, provenanceStatement)
 	if err != nil {
-		t.Errorf("EvaluateSourceProv() error = %v, want nil", err)
+		t.Fatalf("EvaluateSourceProv() error = %v, want nil", err)
 	}
-	if policyPath != expectedPolicyFilePath {
-		t.Errorf("EvaluateSourceProv() policyPath = %q, want %q", policyPath, expectedPolicyFilePath)
+	if result.PolicyPath != expectedPolicyFilePath {
+		t.Errorf("EvaluateSourceProv() policyPath = %q, want %q", result.PolicyPath, expectedPolicyFilePath)
+	}
+	if result.Shortfall != nil {
+		t.Errorf("EvaluateSourceProv() shortfall = %+v, want nil", result.Shortfall)
 	}
 	expectedLevels := slsa.SourceVerifiedLevels{slsa.ControlName(slsa.SlsaSourceLevel3), slsa.SLSA_SOURCE_SCS_TWO_PARTY_REVIEW, slsa.SLSA_SOURCE_SCS_PROTECTED_REFS, "ORG_SOURCE_TESTED"}
-	if !slices.Equal(verifiedLevels, expectedLevels) {
-		t.Errorf("EvaluateSourceProv() verifiedLevels = %v, want %v", verifiedLevels, expectedLevels)
+	if !slices.Equal(result.VerifiedLevels, expectedLevels) {
+		t.Errorf("EvaluateSourceProv() verifiedLevels = %v, want %v", result.VerifiedLevels, expectedLevels)
 	}
 }
 
@@ -251,11 +254,14 @@ func TestEvaluateSourceProv_Failure(t *testing.T) {
 		expectedErrorContains string
 	}{
 		{
-			name:                  "Valid L2 Prov, Policy L3 -> Error (controls don't meet policy)",
-			policyContent:         &policyL3ReviewTagsNow,                                                                       // Expects L3
+			// The SLSA level itself now downgrades instead of erroring; this
+			// policy also requires review, which the L2 controls lack, so a hard
+			// error still results from the (additive) review control.
+			name:                  "Valid L2 Prov, Policy L3+Review -> Error (review control missing)",
+			policyContent:         &policyL3ReviewTagsNow,                                                                       // Expects L3 + review
 			provenanceStatement:   createStatementForTest(t, &validProvPredicateL2Controls, provenance.SourceProvPredicateType), // Prov only has L2 controls
 			ghConnBranch:          "main",
-			expectedErrorContains: "but branch is only eligible for SLSA_SOURCE_LEVEL_2",
+			expectedErrorContains: "policy requires review, but that control is not enabled",
 		},
 		{
 			name:                  "Malformed Policy JSON -> Error",
@@ -319,7 +325,7 @@ func TestEvaluateSourceProv_Failure(t *testing.T) {
 				pe.UseLocalPolicy = policyFilePath
 			}
 
-			_, _, err := pe.EvaluateSourceProv(ctx, &models.Repository{
+			_, err := pe.EvaluateSourceProv(ctx, &models.Repository{
 				Hostname: "github.com",
 				Path:     "local/local",
 			}, &models.Branch{
@@ -332,6 +338,47 @@ func TestEvaluateSourceProv_Failure(t *testing.T) {
 				t.Errorf("EvaluateSourceProv() error = %q, want error containing %q", err.Error(), tt.expectedErrorContains)
 			}
 		})
+	}
+}
+
+// TestEvaluateSourceProv_Shortfall verifies that a SLSA level below the policy
+// target downgrades to the achievable level and reports a shortfall instead of
+// erroring, so provenance can still be emitted.
+func TestEvaluateSourceProv_Shortfall(t *testing.T) {
+	// Policy targets L3 with no additional control requirements.
+	policyL3NoExtras := RepoPolicy{
+		ProtectedBranches: []*ProtectedBranch{
+			{Name: "main", TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel3), Since: timestamppb.New(fixedTime)},
+		},
+	}
+	// Provenance only carries L2 controls.
+	provPredL2 := provenance.SourceProvenancePred{
+		Controls: controlsForLevel(slsa.SlsaSourceLevel2, &earlierFixedTime).ToProvenanceControls(),
+	}
+	stmt := createStatementForTest(t, &provPredL2, provenance.SourceProvPredicateType)
+
+	policyFilePath := createTempPolicyFile(t, &policyL3NoExtras)
+	defer os.Remove(policyFilePath) //nolint:errcheck
+	pe := &PolicyEvaluator{UseLocalPolicy: policyFilePath}
+
+	result, err := pe.EvaluateSourceProv(t.Context(), &models.Repository{
+		Hostname: "github.com",
+		Path:     "local/local",
+	}, &models.Branch{Name: "main"}, stmt)
+	if err != nil {
+		t.Fatalf("EvaluateSourceProv() error = %v, want nil (a shortfall must not error)", err)
+	}
+	if result.Shortfall == nil {
+		t.Fatalf("EvaluateSourceProv() shortfall = nil, want non-nil")
+	}
+	if result.Shortfall.TargetLevel != slsa.SlsaSourceLevel3 {
+		t.Errorf("shortfall.TargetLevel = %v, want %v", result.Shortfall.TargetLevel, slsa.SlsaSourceLevel3)
+	}
+	if result.Shortfall.AchievedLevel != slsa.SlsaSourceLevel2 {
+		t.Errorf("shortfall.AchievedLevel = %v, want %v", result.Shortfall.AchievedLevel, slsa.SlsaSourceLevel2)
+	}
+	if !slices.Contains(result.VerifiedLevels, slsa.ControlName(slsa.SlsaSourceLevel2)) {
+		t.Errorf("verifiedLevels = %v, want it to contain %v", result.VerifiedLevels, slsa.SlsaSourceLevel2)
 	}
 }
 
@@ -433,19 +480,19 @@ func TestEvaluateTagProv_Success(t *testing.T) {
 			defer os.Remove(expectedPolicyFilePath) //nolint:errcheck
 			pe := &PolicyEvaluator{UseLocalPolicy: expectedPolicyFilePath}
 
-			verifiedLevels, policyPath, err := pe.EvaluateTagProv(t.Context(), &models.Repository{
+			result, err := pe.EvaluateTagProv(t.Context(), &models.Repository{
 				Hostname:      "github.com",
 				Path:          "local/local",
 				DefaultBranch: "main",
 			}, provenanceStatement)
 			if err != nil {
-				t.Errorf("EvaluateTagProv() error = %v, want nil", err)
+				t.Fatalf("EvaluateTagProv() error = %v, want nil", err)
 			}
-			if policyPath != expectedPolicyFilePath {
-				t.Errorf("EvaluateTagProv() policyPath = %q, want %q", policyPath, expectedPolicyFilePath)
+			if result.PolicyPath != expectedPolicyFilePath {
+				t.Errorf("EvaluateTagProv() policyPath = %q, want %q", result.PolicyPath, expectedPolicyFilePath)
 			}
-			if !slices.Equal(verifiedLevels, tt.expectedLevels) {
-				t.Errorf("EvaluateTagProv() verifiedLevels = %v, want %v", verifiedLevels, tt.expectedLevels)
+			if !slices.Equal(result.VerifiedLevels, tt.expectedLevels) {
+				t.Errorf("EvaluateTagProv() verifiedLevels = %v, want %v", result.VerifiedLevels, tt.expectedLevels)
 			}
 		})
 	}
@@ -542,22 +589,22 @@ func TestEvaluateControl_Success(t *testing.T) {
 				}
 			}
 
-			verifiedLevels, policyPath, err := pe.EvaluateControl(
+			result, err := pe.EvaluateControl(
 				ctx,
 				&models.Repository{Hostname: "github.com", Path: "local/local"},
 				&models.Branch{Name: tt.ghConnBranch}, tt.controlStatus,
 			)
 			if err != nil {
-				t.Errorf("EvaluateControl() error = %v, want nil", err)
+				t.Fatalf("EvaluateControl() error = %v, want nil", err)
 			}
 
-			if policyPath != actualPolicyPath {
-				t.Errorf("EvaluateControl() policyPath = %q, want %q", policyPath, actualPolicyPath)
+			if result.PolicyPath != actualPolicyPath {
+				t.Errorf("EvaluateControl() policyPath = %q, want %q", result.PolicyPath, actualPolicyPath)
 			}
 
-			if !reflect.DeepEqual(verifiedLevels, tt.expectedLevels) {
-				if len(verifiedLevels) != 0 || len(tt.expectedLevels) != 0 {
-					t.Errorf("EvaluateControl() verifiedLevels = %v, want %v", verifiedLevels, tt.expectedLevels)
+			if !reflect.DeepEqual(result.VerifiedLevels, tt.expectedLevels) {
+				if len(result.VerifiedLevels) != 0 || len(tt.expectedLevels) != 0 {
+					t.Errorf("EvaluateControl() verifiedLevels = %v, want %v", result.VerifiedLevels, tt.expectedLevels)
 				}
 			}
 		})
@@ -585,14 +632,16 @@ func TestEvaluateControl_Failure(t *testing.T) {
 		expectedErrorContains string
 	}{
 		{
-			name:          "Commit time after policy Since, controls DO NOT meet policy -> Error",
+			// The SLSA level downgrades silently now; the hard error comes from
+			// the policy's review requirement, which the L2 controls don't meet.
+			name:          "Commit time after policy Since, review required but missing -> Error",
 			policyContent: &policyL3Review,
 			controlStatus: &slsa.ControlSet{
 				Time:     later.AsTime(),
 				Controls: controlsForLevel(slsa.SlsaSourceLevel2, &rearlier).Controls,
 			},
 			ghConnBranch:          "main",
-			expectedErrorContains: "but branch is only eligible for SLSA_SOURCE_LEVEL_2",
+			expectedErrorContains: "policy requires review, but that control is not enabled",
 		},
 		{
 			name:          "Malformed JSON -> Error",
@@ -627,7 +676,7 @@ func TestEvaluateControl_Failure(t *testing.T) {
 				pe.UseLocalPolicy = policyFilePath
 			}
 
-			_, _, err := pe.EvaluateControl(
+			_, err := pe.EvaluateControl(
 				ctx, &models.Repository{
 					Hostname: "github.com", Path: "local/local",
 				},
@@ -772,6 +821,7 @@ func TestEvaluateBranchControls(t *testing.T) {
 	policyL1NoExtras := ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel1), RequireReview: false, Since: timestamppb.New(fixedTime)}
 	policyL2Review := ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel2), RequireReview: true, Since: timestamppb.New(fixedTime)}
 	policyL2NoReview := ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel2), RequireReview: false, Since: timestamppb.New(fixedTime)}
+	policyL3NoReview := ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel3), RequireReview: false, Since: timestamppb.New(fixedTime)}
 
 	// Tag policies
 	tagHygienePolicy := ProtectedTag{Since: timestamppb.New(fixedTime), TagHygiene: true}
@@ -788,6 +838,8 @@ func TestEvaluateBranchControls(t *testing.T) {
 		expectedLevels        slsa.SourceVerifiedLevels
 		expectError           bool
 		expectedErrorContains string
+		expectShortfall       bool
+		expectedAchievedLevel slsa.SlsaSourceLevel
 	}{
 		{
 			name:           "Success - L3, Review, Tags",
@@ -832,13 +884,14 @@ func TestEvaluateBranchControls(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:                  "Error - computeSlsaLevel Fails (Policy L3, Controls L1)",
-			branchPolicy:          &policyL3Review,
+			name:                  "Shortfall - SLSA level below target downgrades, no error (Policy L3, Controls L1)",
+			branchPolicy:          &policyL3NoReview,
 			tagPolicy:             &noTagHygienePolicy,
-			controls:              &slsa.ControlSet{},
-			expectedLevels:        slsa.SourceVerifiedLevels{},
-			expectError:           true,
-			expectedErrorContains: "but branch is only eligible for SLSA_SOURCE_LEVEL_1",
+			controls:              controlsForLevel(slsa.SlsaSourceLevel1, &earlierFixedTime),
+			expectedLevels:        slsa.SourceVerifiedLevels{slsa.ControlName(slsa.SlsaSourceLevel1)},
+			expectError:           false,
+			expectShortfall:       true,
+			expectedAchievedLevel: slsa.SlsaSourceLevel1,
 		},
 		{
 			name:                  "Error - computeReviewEnforced Fails (Policy L2+Review, Review control missing)",
@@ -870,7 +923,7 @@ func TestEvaluateBranchControls(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLevels, err := evaluateBranchControls(tt.branchPolicy, tt.tagPolicy, tt.controls)
+			gotLevels, shortfall, err := evaluateBranchControls(tt.branchPolicy, tt.tagPolicy, tt.controls)
 
 			if tt.expectError {
 				if err == nil {
@@ -882,6 +935,15 @@ func TestEvaluateBranchControls(t *testing.T) {
 				if err != nil {
 					t.Errorf("evaluateBranchControls() error = %v, want nil", err)
 				}
+			}
+
+			switch {
+			case tt.expectShortfall && shortfall == nil:
+				t.Errorf("evaluateBranchControls() shortfall = nil, want non-nil")
+			case !tt.expectShortfall && shortfall != nil:
+				t.Errorf("evaluateBranchControls() shortfall = %+v, want nil", shortfall)
+			case tt.expectShortfall && shortfall.AchievedLevel != tt.expectedAchievedLevel:
+				t.Errorf("evaluateBranchControls() shortfall.AchievedLevel = %v, want %v", shortfall.AchievedLevel, tt.expectedAchievedLevel)
 			}
 
 			// Sort slices for robust comparison
@@ -1144,7 +1206,7 @@ func TestComputeOrgControls(t *testing.T) {
 	}
 }
 
-func TestComputeSlsaLevel(t *testing.T) {
+func TestComputeAchievableSlsaLevel(t *testing.T) {
 	rnow := time.Now()
 	now := &rnow
 	rearlier := time.Now().Add(-time.Hour)
@@ -1157,102 +1219,101 @@ func TestComputeSlsaLevel(t *testing.T) {
 	policyUnknownLevel := ProtectedBranch{TargetSlsaSourceLevel: "UNKNOWN_LEVEL", Since: timestamppb.New(rnow)}
 
 	tests := []struct {
-		name                  string
-		branchPolicy          *ProtectedBranch
-		controls              *slsa.ControlSet
-		expectedLevels        []slsa.ControlName
-		expectError           bool
-		expectedErrorContains string
+		name            string
+		branchPolicy    *ProtectedBranch
+		controls        *slsa.ControlSet
+		expectedLevel   slsa.SlsaSourceLevel
+		expectShortfall bool
 	}{
 		{
-			name:           "Controls L4-eligible (since 'earlier'), Policy L4 (since 'now'): success",
-			branchPolicy:   &policyL4Now,
-			controls:       controlsForLevel(slsa.SlsaSourceLevel4, earlier),
-			expectedLevels: []slsa.ControlName{slsa.ControlName(slsa.SlsaSourceLevel4)},
-			expectError:    false,
+			name:          "Controls L4-eligible (since 'earlier'), Policy L4 (since 'now'): target met",
+			branchPolicy:  &policyL4Now,
+			controls:      controlsForLevel(slsa.SlsaSourceLevel4, earlier),
+			expectedLevel: slsa.SlsaSourceLevel4,
 		},
 		{
-			name:           "Controls L3-eligible (since 'earlier'), Policy L2 (since 'now'): success",
-			branchPolicy:   &policyL2Now,
-			controls:       controlsForLevel(slsa.SlsaSourceLevel3, earlier),
-			expectedLevels: []slsa.ControlName{slsa.ControlName(slsa.SlsaSourceLevel2)},
-			expectError:    false,
+			name:          "Controls L3-eligible (since 'earlier'), Policy L2 (since 'now'): capped at target, met",
+			branchPolicy:  &policyL2Now,
+			controls:      controlsForLevel(slsa.SlsaSourceLevel3, earlier),
+			expectedLevel: slsa.SlsaSourceLevel2,
 		},
 		{
-			name:                  "Controls L1-eligible, Policy L2: fail (eligibility)",
-			branchPolicy:          &policyL2Now,
-			controls:              &slsa.ControlSet{},
-			expectedLevels:        []slsa.ControlName{},
-			expectError:           true,
-			expectedErrorContains: "but branch is only eligible for SLSA_SOURCE_LEVEL_1",
+			name:            "Controls L1-eligible, Policy L2: downgrade to L1",
+			branchPolicy:    &policyL2Now,
+			controls:        &slsa.ControlSet{},
+			expectedLevel:   slsa.SlsaSourceLevel1,
+			expectShortfall: true,
 		},
 		{
-			name:           "Eligible L3 (since 'earlier'), Policy L3 (since 'now'): compliant Policy.Since",
-			branchPolicy:   &policyL3Now,
-			controls:       controlsForLevel(slsa.SlsaSourceLevel3, earlier),
-			expectedLevels: []slsa.ControlName{slsa.ControlName(slsa.SlsaSourceLevel3)},
-			expectError:    false,
+			name:          "Eligible L3 (since 'earlier'), Policy L3 (since 'now'): target met",
+			branchPolicy:  &policyL3Now,
+			controls:      controlsForLevel(slsa.SlsaSourceLevel3, earlier),
+			expectedLevel: slsa.SlsaSourceLevel3,
 		},
 		{
-			name:                  "Controls L4-eligible (since 'now'), Policy L4 (since 'earlier'): fail (Policy.Since too early)",
-			branchPolicy:          &ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel4), Since: timestamppb.New(*earlier)},
-			controls:              controlsForLevel(slsa.SlsaSourceLevel4, now),
-			expectedLevels:        []slsa.ControlName{},
-			expectError:           true,
-			expectedErrorContains: "policy sets target level SLSA_SOURCE_LEVEL_4 since",
+			name:            "Controls L4-eligible (since 'now'), Policy L4 (since 'earlier'): downgrade (Policy.Since too early)",
+			branchPolicy:    &ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel4), Since: timestamppb.New(*earlier)},
+			controls:        controlsForLevel(slsa.SlsaSourceLevel4, now),
+			expectedLevel:   slsa.SlsaSourceLevel1,
+			expectShortfall: true,
 		},
 		{
-			name:                  "Controls L3-eligible (since 'now'), Policy L3 (since 'earlier'): fail (Policy.Since too early)",
-			branchPolicy:          &ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel3), Since: timestamppb.New(*earlier)},
-			controls:              controlsForLevel(slsa.SlsaSourceLevel3, now),
-			expectedLevels:        []slsa.ControlName{},
-			expectError:           true,
-			expectedErrorContains: "policy sets target level SLSA_SOURCE_LEVEL_3 since",
+			name:            "Controls L3-eligible (since 'now'), Policy L3 (since 'earlier'): downgrade (Policy.Since too early)",
+			branchPolicy:    &ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel3), Since: timestamppb.New(*earlier)},
+			controls:        controlsForLevel(slsa.SlsaSourceLevel3, now),
+			expectedLevel:   slsa.SlsaSourceLevel1,
+			expectShortfall: true,
 		},
 		{
-			name:                  "Controls L2-eligible (since 'now'), Policy L2 (since 'earlier'): fail (Policy.Since too early)",
-			branchPolicy:          &ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel2), Since: timestamppb.New(*earlier)},
-			controls:              controlsForLevel(slsa.SlsaSourceLevel2, now),
-			expectedLevels:        []slsa.ControlName{},
-			expectError:           true,
-			expectedErrorContains: "policy sets target level SLSA_SOURCE_LEVEL_2 since",
+			name:            "Controls L2-eligible (since 'now'), Policy L2 (since 'earlier'): downgrade (Policy.Since too early)",
+			branchPolicy:    &ProtectedBranch{TargetSlsaSourceLevel: string(slsa.SlsaSourceLevel2), Since: timestamppb.New(*earlier)},
+			controls:        controlsForLevel(slsa.SlsaSourceLevel2, now),
+			expectedLevel:   slsa.SlsaSourceLevel1,
+			expectShortfall: true,
 		},
 		{
-			name:                  "Policy L?'UNKNOWN' (controls L3-eligible): fail (policy target unknown)",
-			branchPolicy:          &policyUnknownLevel,
-			controls:              controlsForLevel(slsa.SlsaSourceLevel3, now),
-			expectedLevels:        []slsa.ControlName{},
-			expectError:           true,
-			expectedErrorContains: "policy sets target level UNKNOWN_LEVEL",
+			// An unknown/typo'd target level sorts above the real levels, so it
+			// can never be "met": we stamp the highest eligible level and report
+			// a shortfall rather than erroring.
+			name:            "Policy 'UNKNOWN' target (controls L3-eligible): downgrade to eligible level",
+			branchPolicy:    &policyUnknownLevel,
+			controls:        controlsForLevel(slsa.SlsaSourceLevel3, now),
+			expectedLevel:   slsa.SlsaSourceLevel3,
+			expectShortfall: true,
 		},
 		{
-			name:                  "Controls L1-eligible, Policy L3: fail (eligibility)",
-			branchPolicy:          &policyL3Now,
-			controls:              &slsa.ControlSet{},
-			expectedLevels:        []slsa.ControlName{},
-			expectError:           true,
-			expectedErrorContains: "but branch is only eligible for SLSA_SOURCE_LEVEL_1",
+			name:            "Controls L1-eligible, Policy L3: downgrade to L1",
+			branchPolicy:    &policyL3Now,
+			controls:        &slsa.ControlSet{},
+			expectedLevel:   slsa.SlsaSourceLevel1,
+			expectShortfall: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLevels, err := computeSlsaLevel(tt.branchPolicy, nil, tt.controls)
+			gotLevel, shortfall := computeAchievableSlsaLevel(tt.branchPolicy, tt.controls)
 
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("computeSlsaLevel() error = nil, want non-nil error containing %q", tt.expectedErrorContains)
-				} else if !strings.Contains(err.Error(), tt.expectedErrorContains) {
-					t.Errorf("computeSlsaLevel() error = %q, want error containing %q", err.Error(), tt.expectedErrorContains)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("computeSlsaLevel() error = %v, want nil", err)
-				}
+			if gotLevel != tt.expectedLevel {
+				t.Errorf("computeAchievableSlsaLevel() level = %v, want %v", gotLevel, tt.expectedLevel)
 			}
 
-			if !slices.Equal(gotLevels, tt.expectedLevels) {
-				t.Errorf("computeSlsaLevel() gotLevel = %v, want %v", gotLevels, tt.expectedLevels)
+			switch {
+			case tt.expectShortfall && shortfall == nil:
+				t.Errorf("computeAchievableSlsaLevel() shortfall = nil, want non-nil")
+			case !tt.expectShortfall && shortfall != nil:
+				t.Errorf("computeAchievableSlsaLevel() shortfall = %+v, want nil", shortfall)
+			case tt.expectShortfall && shortfall != nil:
+				if shortfall.AchievedLevel != tt.expectedLevel {
+					t.Errorf("computeAchievableSlsaLevel() shortfall.AchievedLevel = %v, want %v", shortfall.AchievedLevel, tt.expectedLevel)
+				}
+				wantTarget := slsa.SlsaSourceLevel(tt.branchPolicy.GetTargetSlsaSourceLevel())
+				if shortfall.TargetLevel != wantTarget {
+					t.Errorf("computeAchievableSlsaLevel() shortfall.TargetLevel = %v, want %v", shortfall.TargetLevel, wantTarget)
+				}
+				if shortfall.Reason == "" {
+					t.Errorf("computeAchievableSlsaLevel() shortfall.Reason is empty, want non-empty")
+				}
 			}
 		})
 	}

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -377,11 +377,20 @@ var defaultAttestOptions = AttestOptions{
 	UseStdOut: true,
 }
 
+// AttestationResult is the outcome of attesting a revision.
+// Both attestations are always produced (and optionally pushed) regardless of
+// whether the policy's target level was achieved. Shortfall will be not nil
+// when the achieved SLSA level is below the policy's target.
+type AttestationResult struct {
+	VerifiedLevels slsa.SourceVerifiedLevels
+	Shortfall      *policy.PolicyShortfall
+}
+
 // AttestRevision checks the source control system status, the repository policy
 // and generates the repository attestations (provenance & VSA) for a revision
 func (t *Tool) AttestRevision(
 	ctx context.Context, branch *models.Branch, rev models.Revision, funcs ...AttOpFn,
-) (slsa.SourceVerifiedLevels, error) {
+) (*AttestationResult, error) {
 	var agent *collector.Agent
 	var err error
 
@@ -405,6 +414,7 @@ func (t *Tool) AttestRevision(
 	var provenanceData []byte
 	var verifiedLevels slsa.SourceVerifiedLevels
 	var policyPath string
+	var shortfall *policy.PolicyShortfall
 
 	_, isCommit := rev.(*models.Commit)
 	tag, isTag := rev.(*models.Tag)
@@ -416,14 +426,17 @@ func (t *Tool) AttestRevision(
 			return nil, err
 		}
 
-		// 2. Run the provenance against the policy to determine if the controls
-		// are still in the context and timelines of the policy.
+		// 2. Run the provenance against the policy to determine the verified
+		// levels. Any level below the policy target is reported as a shortfall, not
+		// an error. We still emit the provenance so the chain is never broken
+		// just because the policy levels are not met immediately.
 		pe := policy.NewPolicyEvaluator()
 		pe.UseLocalPolicy = opts.LocalPolicy
-		verifiedLevels, policyPath, err = pe.EvaluateSourceProv(ctx, branch.Repository, branch, prov)
+		result, err := pe.EvaluateSourceProv(ctx, branch.Repository, branch, prov)
 		if err != nil {
 			return nil, fmt.Errorf("evaluating provenance with policy: %w", err)
 		}
+		verifiedLevels, policyPath, shortfall = result.VerifiedLevels, result.PolicyPath, result.Shortfall
 
 		provenanceData, err = protojson.Marshal(prov)
 		if err != nil {
@@ -438,14 +451,14 @@ func (t *Tool) AttestRevision(
 			return nil, err
 		}
 
-		// 2. Run the provenance against the policy to determine if the controls
-		// are still in the context and timelines of the policy.
+		// 2. Run the provenance against the policy to determine the verified levels.
 		pe := policy.NewPolicyEvaluator()
 		pe.UseLocalPolicy = opts.LocalPolicy
-		verifiedLevels, policyPath, err = pe.EvaluateTagProv(ctx, branch.Repository, prov)
+		result, err := pe.EvaluateTagProv(ctx, branch.Repository, prov)
 		if err != nil {
 			return nil, fmt.Errorf("evaluating provenance with policy: %w", err)
 		}
+		verifiedLevels, policyPath, shortfall = result.VerifiedLevels, result.PolicyPath, result.Shortfall
 
 		provenanceData, err = protojson.Marshal(prov)
 		if err != nil {
@@ -506,7 +519,10 @@ func (t *Tool) AttestRevision(
 		}
 	}
 
-	return verifiedLevels, nil
+	return &AttestationResult{
+		VerifiedLevels: verifiedLevels,
+		Shortfall:      shortfall,
+	}, nil
 }
 
 // getAttestationStore returns a collector with storer reposistories to push


### PR DESCRIPTION
This PR updates sourcetool to always generate provenance with the accurate source level.

When a repository has changes that downgrade its slsa level, instead of failing and refusing to issue provenance, we issue the right provenance attestation with the  passing controls and the VSA with the downgraded level. `sourcetool checklevel` will still exit non-zero by default but having the provenance allows the user to recover without ugly hacks (see #400 for details).

The attestation evaluation now returns the details when we fail to meet the policy requirements. Also, we introduce a new `--silent-downgrade` flag to control  if we exit non zero when the slsa level is downgraded.

Closes #400 