### PR TITLE
Push using dynamic notes URL

### DIFF
--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -570,7 +570,7 @@ func (t *Tool) getAttestationStore(branch *models.Branch) (*collector.Agent, err
 	// Init commit notes storer
 	if t.Options.InitNotesStorer {
 		notesrepo, err := note.NewDynamic(
-			note.WithLocator(branch.Repository.GetHttpURL()),
+			note.DynamicRepoURL(branch.Repository.GetHttpURL()),
 			note.WithHttpAuth("github", token),
 			note.WithPush(true),
 		)


### PR DESCRIPTION
This change modifies the call to the collector to store the attestations using the DynamicURL init string 