### PR TITLE
Bump linter version and fix all nits

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -39,4 +39,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11
+          version: v2.12

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -110,6 +110,9 @@ linters:
     - zerologlint
 
   settings:
+    goconst:
+      # Repeated literals in table driven tests don't warrant constants.
+      ignore-tests: true
     gocyclo:
       min-complexity: 35
     godox:

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -23,6 +23,9 @@ const (
 const (
 	statusPassed = "passed"
 	statusFailed = "failed"
+
+	auditModeBasicName = "basic"
+	auditModeFullName  = "full"
 )
 
 // Enable audit mode enum
@@ -30,9 +33,9 @@ const (
 func (e *AuditMode) String() string {
 	switch *e {
 	case AuditModeBasic:
-		return "basic"
+		return auditModeBasicName
 	case AuditModeFull:
-		return "full"
+		return auditModeFullName
 	}
 	return "error"
 }
@@ -40,14 +43,14 @@ func (e *AuditMode) String() string {
 // Set must have pointer receiver so it doesn't change the value of a copy
 func (e *AuditMode) Set(v string) error {
 	switch v {
-	case "basic":
+	case auditModeBasicName:
 		*e = AuditModeBasic
 		return nil
-	case "full":
+	case auditModeFullName:
 		*e = AuditModeFull
 		return nil
 	default:
-		return errors.New(`must be one of "foo", "bar", or "moo"`)
+		return fmt.Errorf("must be one of %q or %q", auditModeBasicName, auditModeFullName)
 	}
 }
 
@@ -119,7 +122,7 @@ func addAudit(parentCmd *cobra.Command) {
 	opts := &auditOpts{}
 	auditCmd := &cobra.Command{
 		Use:     "audit",
-		GroupID: "verification",
+		GroupID: cmdGroupVerification,
 		Short:   "Verifies multiple commits in the branch history",
 		Long: `Checks the revisions on the specified branch within the repository.
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -18,7 +18,7 @@ var colorHiRed = color.New(color.FgHiRed).SprintFunc()
 
 func addAuth(parentCmd *cobra.Command) {
 	authCmd := &cobra.Command{
-		GroupID:       "configuration",
+		GroupID:       cmdGroupConfiguration,
 		Short:         "Manage user authentication",
 		Use:           "auth",
 		SilenceUsage:  false,

--- a/internal/cmd/checklevel.go
+++ b/internal/cmd/checklevel.go
@@ -44,7 +44,7 @@ func addCheckLevel(parentCmd *cobra.Command) {
 
 	checklevelCmd := &cobra.Command{
 		Use:     "checklevel",
-		GroupID: "assessment",
+		GroupID: cmdGroupAssessment,
 		Short:   "Determines the SLSA Source Level of the repo",
 		Long: `Determines the SLSA Source Level of the repo.
 

--- a/internal/cmd/checklevelprov.go
+++ b/internal/cmd/checklevelprov.go
@@ -89,7 +89,7 @@ func addCheckLevelProv(parentCmd *cobra.Command) {
 
 	checklevelprovCmd := &cobra.Command{
 		Use:     "checklevelprov",
-		GroupID: "assessment",
+		GroupID: cmdGroupAssessment,
 		Example: `sourcetool checklevelprov owner/repo --push=note`,
 		Short:   "Checks the given commit against policy using & creating provenance",
 		Long: `Checks the given commit against policy using & creating provenance.

--- a/internal/cmd/checktag.go
+++ b/internal/cmd/checktag.go
@@ -55,7 +55,7 @@ func addCheckTag(parentCmd *cobra.Command) {
 
 	checktagCmd := &cobra.Command{
 		Use:     "checktag",
-		GroupID: "assessment",
+		GroupID: cmdGroupAssessment,
 		Short:   "Checks to see if the tag operation should be allowed and issues a VSA",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {

--- a/internal/cmd/createpolicy.go
+++ b/internal/cmd/createpolicy.go
@@ -31,7 +31,7 @@ func addCreatePolicy(parentCmd *cobra.Command) {
 
 	createpolicyCmd := &cobra.Command{
 		Use:     "createpolicy",
-		GroupID: "policy",
+		GroupID: cmdGroupPolicy,
 		Short:   "Creates a policy in a local copy of source-policies",
 		Long: `Creates a SLSA source policy in a local copy of source-policies.
 

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -39,7 +39,7 @@ func (pco *policyCreateOpts) AddFlags(cmd *cobra.Command) {
 
 func addPolicy(parentCmd *cobra.Command) {
 	policyCmd := &cobra.Command{
-		GroupID: "policy",
+		GroupID: cmdGroupPolicy,
 		Short:   "tools to work with source policies",
 		Long: fmt.Sprintf(`
 %s %s

--- a/internal/cmd/prov.go
+++ b/internal/cmd/prov.go
@@ -39,7 +39,7 @@ func addProv(parentCmd *cobra.Command) {
 	opts := provOptions{}
 	provCmd := &cobra.Command{
 		Use:     "prov",
-		GroupID: "assessment",
+		GroupID: cmdGroupAssessment,
 		Short:   "Creates provenance for the given commit, but does not check policy.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,16 +15,13 @@ import (
 
 var githubToken string
 
-// func getVerifier(vo *verifierOptions) attest.Verifier {
-// 	options := attest.DefaultVerifierOptions
-// 	if vo.expectedIssuer != "" {
-// 		options.ExpectedIssuer = vo.expectedIssuer
-// 	}
-// 	if vo.expectedSan != "" {
-// 		options.ExpectedSan = vo.expectedSan
-// 	}
-// 	return attest.NewBndVerifier(options)
-// }
+// Command group IDs used to organize the subcommands in the help screen.
+const (
+	cmdGroupVerification  = "verification"
+	cmdGroupAssessment    = "assessment"
+	cmdGroupPolicy        = "policy"
+	cmdGroupConfiguration = "configuration"
+)
 
 // exitError wraps an error together with an exit code so commands can
 // signal other failuresdistinct from a generic failure (exit 1).
@@ -58,19 +55,19 @@ controls and much more.
 	// Define command groups for better organization
 	rootCmd.AddGroup(
 		&cobra.Group{
-			ID:    "verification",
+			ID:    cmdGroupVerification,
 			Title: "Verification Commands:",
 		},
 		&cobra.Group{
-			ID:    "assessment",
+			ID:    cmdGroupAssessment,
 			Title: "Assessment Commands:",
 		},
 		&cobra.Group{
-			ID:    "policy",
+			ID:    cmdGroupPolicy,
 			Title: "Policy Commands:",
 		},
 		&cobra.Group{
-			ID:    "configuration",
+			ID:    cmdGroupConfiguration,
 			Title: "Configuration & Setup Commands:",
 		},
 	)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -52,7 +52,7 @@ func (so *setupOpts) Validate() error {
 
 func addSetup(parentCmd *cobra.Command) {
 	setupCmd := &cobra.Command{
-		GroupID: "configuration",
+		GroupID: cmdGroupConfiguration,
 		Short:   "configure SLSA source features in a repository",
 		Long: fmt.Sprintf(`
 %s %s

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -47,7 +47,7 @@ func (so *statusOptions) AddFlags(cmd *cobra.Command) {
 func addStatus(parentCmd *cobra.Command) {
 	opts := &statusOptions{}
 	statusCmd := &cobra.Command{
-		GroupID: "assessment",
+		GroupID: cmdGroupAssessment,
 		Short:   "Check the SLSA Source status of a repo/branch",
 		Long: `
 sourcetool status: Check the SLSA Source status of a repo/branch

--- a/internal/cmd/verifycommit.go
+++ b/internal/cmd/verifycommit.go
@@ -18,6 +18,12 @@ type verifyCommitOptions struct {
 	revisionOpts
 }
 
+// Ref types reported in the verification results
+const (
+	refTypeBranch = "branch"
+	refTypeTag    = "tag"
+)
+
 // VerifyCommitResult represents the result of a commit verification
 type VerifyCommitResult struct {
 	Success        bool     `json:"success"`
@@ -58,7 +64,7 @@ func addVerifyCommit(cmd *cobra.Command) {
 	opts := verifyCommitOptions{}
 	verifyCommitCmd := &cobra.Command{
 		Use:     "verifycommit",
-		GroupID: "verification",
+		GroupID: cmdGroupVerification,
 		Short:   "Verifies the specified commit is valid",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
@@ -101,10 +107,10 @@ func addVerifyCommit(cmd *cobra.Command) {
 			var refName string
 			switch {
 			case opts.branch != "":
-				refType = "branch"
+				refType = refTypeBranch
 				refName = opts.branch
 			case opts.tag != "":
-				refType = "tag"
+				refType = refTypeTag
 				refName = opts.tag
 			default:
 				return fmt.Errorf("must specify either branch or tag")

--- a/pkg/attest/attester.go
+++ b/pkg/attest/attester.go
@@ -206,7 +206,7 @@ func addPredToStatement(provPred proto.Message, predicateType, commit string) (*
 	}
 
 	sub := []*intoto.ResourceDescriptor{{
-		Digest: map[string]string{"gitCommit": commit},
+		Digest: map[string]string{models.DigestTypeGitCommit: commit},
 	}}
 
 	var predPb structpb.Struct

--- a/pkg/attest/statement.go
+++ b/pkg/attest/statement.go
@@ -48,12 +48,12 @@ func GetSubjectForCommit(att attestation.Envelope, commit *models.Commit) *intot
 		if !ok {
 			continue
 		}
-		val, ok := rd.GetDigest()["gitCommit"]
+		val, ok := rd.GetDigest()[models.DigestTypeGitCommit]
 		if ok && val == commit.SHA {
 			return rd
 		}
 
-		if val, ok = rd.GetDigest()["sha1"]; ok && val == commit.SHA {
+		if val, ok = rd.GetDigest()[models.DigestTypeSha1]; ok && val == commit.SHA {
 			fromSha = rd
 		}
 	}

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -51,7 +51,7 @@ func createUnsignedSourceVsaAllParams(branch *models.Branch, commit *models.Comm
 		return "", fmt.Errorf("creating struct from map: %w", err)
 	}
 	sub := []*spb.ResourceDescriptor{{
-		Digest:      map[string]string{"gitCommit": commit.SHA},
+		Digest:      map[string]string{models.DigestTypeGitCommit: commit.SHA},
 		Annotations: annotationStruct,
 	}}
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -34,6 +34,10 @@ const (
 	SourcePolicyUri       = "github.com/slsa-framework/source-policies"
 	SourcePolicyRepoOwner = "slsa-framework"
 	SourcePolicyRepo      = "source-policies"
+
+	// DefaultPolicyPath is the policy path reported when a branch is
+	// evaluated using the default policy.
+	DefaultPolicyPath = "DEFAULT"
 )
 
 // Returns the policy for the branch or nil if the branch doesn't have one.
@@ -635,7 +639,7 @@ func (pe *PolicyEvaluator) EvaluateControl(ctx context.Context, repo *models.Rep
 	branchPolicy := rp.GetBranchPolicy(branch.Name)
 	if branchPolicy == nil {
 		branchPolicy = createDefaultBranchPolicy(branch)
-		policyPath = "DEFAULT"
+		policyPath = DefaultPolicyPath
 	}
 
 	if controlStatus.Time.Before(branchPolicy.GetSince().AsTime()) {
@@ -675,7 +679,7 @@ func (pe *PolicyEvaluator) EvaluateSourceProv(ctx context.Context, repo *models.
 	branchPolicy := rp.GetBranchPolicy(branch.Name)
 	if branchPolicy == nil {
 		branchPolicy = createDefaultBranchPolicy(branch)
-		policyPath = "DEFAULT"
+		policyPath = DefaultPolicyPath
 	}
 
 	verifiedLevels, shortfall, err := evaluateBranchControls(branchPolicy, rp.GetProtectedTag(), slsa.NewControlSetFromProvanenaceControls(provPred.GetControls()))

--- a/pkg/sourcetool/implementation.go
+++ b/pkg/sourcetool/implementation.go
@@ -119,7 +119,7 @@ func (impl *defaultToolImplementation) CreatePolicyPR(a *auth.Authenticator, opt
 	}
 
 	policyRepo := &models.Repository{
-		Hostname:      "github.com",
+		Hostname:      githubHostname,
 		Path:          fmt.Sprintf("%s/%s", policyRepoOwner, policyRepoName),
 		DefaultBranch: "main",
 	}
@@ -163,7 +163,7 @@ func (impl *defaultToolImplementation) CheckForks(opts *options.Options) error {
 func (impl *defaultToolImplementation) CheckPolicyFork(opts *options.Options) error {
 	manager := repo.NewPullRequestManager()
 	if _, err := manager.CheckFork(&models.Repository{
-		Hostname: "github.com", Path: opts.PolicyRepo,
+		Hostname: githubHostname, Path: opts.PolicyRepo,
 	}, ""); err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func (impl *defaultToolImplementation) GetPolicyStatus(
 
 	host := r.Hostname
 	if host == "" {
-		host = "github.com"
+		host = githubHostname
 	}
 	prNr, err := impl.SearchPullRequest(ctx, a, &models.Repository{
 		Hostname: host,

--- a/pkg/sourcetool/models/models.go
+++ b/pkg/sourcetool/models/models.go
@@ -69,6 +69,12 @@ const (
 	CONFIG_TAG_RULES      ControlConfiguration = "CONFIG_TAG_RULES"
 )
 
+// Digest algorithm names used in attestation subjects
+const (
+	DigestTypeGitCommit = "gitCommit"
+	DigestTypeSha1      = "sha1"
+)
+
 type Commit struct {
 	SHA     string
 	Author  string
@@ -101,7 +107,7 @@ func (c *Commit) GetCommit() *Commit {
 func (c *Commit) ToResourceDescriptor() *attestation.ResourceDescriptor {
 	return &attestation.ResourceDescriptor{
 		Digest: map[string]string{
-			"sha1": c.SHA, "gitCommit": c.SHA,
+			DigestTypeSha1: c.SHA, DigestTypeGitCommit: c.SHA,
 		},
 	}
 }

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -36,6 +36,9 @@ var ControlConfigurations = []models.ControlConfiguration{
 	models.CONFIG_POLICY, models.CONFIG_GEN_PROVENANCE, models.CONFIG_BRANCH_RULES, models.CONFIG_TAG_RULES,
 }
 
+// githubHostname is the hostname of the VCS system sourcetool supports (for now)
+const githubHostname = "github.com"
+
 // New initializes a new source tool instance.
 func New(funcs ...ConfigFn) (*Tool, error) {
 	t := &Tool{
@@ -194,7 +197,7 @@ func (t *Tool) FindPolicyPR(ctx context.Context, repo *models.Repository) (*mode
 	}
 
 	pr, err := t.impl.SearchPullRequest(ctx, t.Authenticator, &models.Repository{
-		Hostname: "github.com",
+		Hostname: githubHostname,
 		Path:     fmt.Sprintf("%s/%s", policyRepoOwner, policyRepoRepo),
 	}, fmt.Sprintf("Add %s SLSA Source policy file", repo.Path))
 	if err != nil {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to standardize code, improve maintainability, and enhance configuration flexibility. The most significant changes include replacing hardcoded string literals with named constants, updating command group IDs to use constants for consistency, and updating linter configurations and dependencies.

**Standardization and Refactoring:**

* Introduced named constants for command group IDs (e.g., `cmdGroupVerification`, `cmdGroupAssessment`, etc.) and updated all `cobra.Command` definitions to use these constants instead of string literals. This improves consistency and makes future changes easier. [[1]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dL18-R24) [[2]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dL61-R70) [[3]](diffhunk://#diff-48546baaf33061c87341231c7cfeb2f7bf64b9ea84d694caec683ae510bb344fL122-R125) [[4]](diffhunk://#diff-350c016bab64815e33ac06b0da23a007fa584ec6253aca89186116a11a244e5aL21-R21) [[5]](diffhunk://#diff-3b2963252e8c4a1ba6e4e93d83e7c68308944e2e2975c9c1b09db94872392b97L47-R47) [[6]](diffhunk://#diff-d08bca0e5d3a12bdcf8838880038ad2000d4496b8651813224699a0320de873dL92-R92) [[7]](diffhunk://#diff-ab95fe4433fdd62531dc7243a2c9157c99d0b4ec31623d53691912814906e575L58-R58) [[8]](diffhunk://#diff-819fdc36976469ebfb212cb582a8813a1ee5e386c605c339abae398a92cbb76aL34-R34) [[9]](diffhunk://#diff-2a36f96c7f86ee209a007eb0d7ab850e810dd86bc663fcea63631e8c305cac5cL42-R42) [[10]](diffhunk://#diff-431c9f961a5b06f6626e3b5a674b1415ce5ed1c70d1134e4034c650ec91abf40L42-R42) [[11]](diffhunk://#diff-fd71915fc071972b14be28cf7b5918132d2b131e1e234c96ad7f1030fec3f928L55-R55) [[12]](diffhunk://#diff-6f4dbc56493c3e202d38851ec09224ea6fd384eb6ccf621ec3eb12e7011f38c9L50-R50) [[13]](diffhunk://#diff-d56cb8c42d39caca16b8e48c448d0e7a29502ae9f5890fdab719f5e355c71142L61-R67)
* Replaced hardcoded digest algorithm names (e.g., `"gitCommit"`, `"sha1"`) with named constants (`DigestTypeGitCommit`, `DigestTypeSha1`) in attestation-related code, improving maintainability and reducing risk of typos. [[1]](diffhunk://#diff-fce313a8f1a3a37cf135d1e63dc9684339aae519659d1d5c47f814e71c9d20b9R72-R77) [[2]](diffhunk://#diff-fce313a8f1a3a37cf135d1e63dc9684339aae519659d1d5c47f814e71c9d20b9L104-R110) [[3]](diffhunk://#diff-bc5ee36015daa077ebb7a6f378c3d7b6593d6c5238e1fb004687f7b4693daff7L209-R209) [[4]](diffhunk://#diff-eb54e2a01d529dfe969bc7d74c8b6b47ddeefbbb3609e4e37ede86eb84dac275L51-R56) [[5]](diffhunk://#diff-7664046d969093792032aa1c3a51077f4452194967a4d9fa481ca3c551d12d2dL54-R54)
* Added named constants for audit modes (`auditModeBasicName`, `auditModeFullName`) and ref types (`refTypeBranch`, `refTypeTag`), and updated logic to use these constants. [[1]](diffhunk://#diff-48546baaf33061c87341231c7cfeb2f7bf64b9ea84d694caec683ae510bb344fR26-R53) [[2]](diffhunk://#diff-d56cb8c42d39caca16b8e48c448d0e7a29502ae9f5890fdab719f5e355c71142R21-R26) [[3]](diffhunk://#diff-d56cb8c42d39caca16b8e48c448d0e7a29502ae9f5890fdab719f5e355c71142L104-R113)

**Configuration and Dependency Updates:**

* Updated the `golangci-lint` GitHub Action to use version `v2.12` and switched the `gomodguard` linter to `gomodguard_v2` in `.golangci.yaml`. [[1]](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0L42-R42) [[2]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L63-R63)
* Added configuration to ignore repeated literals in table-driven tests for the `goconst` linter.

**Policy Evaluation Improvements:**

* Introduced a `DefaultPolicyPath` constant and used it in policy evaluation logic to standardize the reporting of default policy paths. [[1]](diffhunk://#diff-65233530cd6c70f508ee7fc22a56d14f41ec672f9d72349e4dd2780b07b98727R37-R40) [[2]](diffhunk://#diff-65233530cd6c70f508ee7fc22a56d14f41ec672f9d72349e4dd2780b07b98727L638-R642) [[3]](diffhunk://#diff-65233530cd6c70f508ee7fc22a56d14f41ec672f9d72349e4dd2780b07b98727L678-R682)
* Centralized the GitHub hostname as a constant (`githubHostname`) for use in policy and repository management logic. [[1]](diffhunk://#diff-35572006824ecbbc134248ad5f702cce99ae15c2069c0317259d2e86282b3cfaL122-R122) [[2]](diffhunk://#diff-35572006824ecbbc134248ad5f702cce99ae15c2069c0317259d2e86282b3cfaL166-R166) [[3]](diffhunk://#diff-35572006824ecbbc134248ad5f702cce99ae15c2069c0317259d2e86282b3cfaL251-R251)