### PR TITLE
COrrect and validate push values (note)

### DIFF
--- a/internal/cmd/checklevelprov.go
+++ b/internal/cmd/checklevelprov.go
@@ -20,8 +20,14 @@ type pushOptions struct {
 	pushRepositories []string
 }
 
+// Repository types supported as push destinations
+const (
+	pushRepoGithub = "github"
+	pushRepoNote   = "note"
+)
+
 // Support repository types to push
-var supportedPushRepos = []string{"github", "note"}
+var supportedPushRepos = []string{pushRepoGithub, pushRepoNote}
 
 // Validate checks the push options
 func (po *pushOptions) Validate() error {
@@ -68,6 +74,7 @@ func (clp *checkLevelProvOpts) Validate() error {
 	return errors.Join([]error{
 		clp.revisionOpts.Validate(),
 		clp.verifierOptions.Validate(),
+		clp.pushOptions.Validate(),
 	}...)
 }
 
@@ -122,6 +129,10 @@ and pushed to its remote (--push=note).
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
 			// Here we need to translate the CLI options to the sourcetool
 			// options. Some of these will be deprecated as some point for
 			// a more concise options set.
@@ -137,14 +148,15 @@ and pushed to its remote (--push=note).
 			}
 
 			var githubStorer, notesStorer, pushAttestations bool
-			switch {
-			case slices.Contains(opts.pushLocation, "github"):
+			if slices.Contains(opts.pushLocation, pushRepoGithub) {
 				pushAttestations = true
 				githubStorer = true
-			case slices.Contains(opts.pushLocation, "notes"):
+			}
+			if slices.Contains(opts.pushLocation, pushRepoNote) {
 				pushAttestations = true
 				notesStorer = true
-			case len(opts.pushRepositories) > 0:
+			}
+			if len(opts.pushRepositories) > 0 {
 				pushAttestations = true
 			}
 

--- a/internal/cmd/checktag.go
+++ b/internal/cmd/checktag.go
@@ -30,6 +30,7 @@ func (cto *checkTagOptions) Validate() error {
 	errs := []error{
 		cto.revisionOpts.Validate(),
 		cto.verifierOptions.Validate(),
+		cto.pushOptions.Validate(),
 	}
 	return errors.Join(errs...)
 }
@@ -74,6 +75,10 @@ func addCheckTag(parentCmd *cobra.Command) {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
 			// Here we need to translate the CLI options to the sourcetool
 			// options. Some of these will be deprecated as some point for
 			// a more concise options set.
@@ -89,14 +94,15 @@ func addCheckTag(parentCmd *cobra.Command) {
 			}
 
 			var githubStorer, notesStorer, pushAttestations bool
-			switch {
-			case slices.Contains(opts.pushLocation, "github"):
+			if slices.Contains(opts.pushLocation, pushRepoGithub) {
 				pushAttestations = true
 				githubStorer = true
-			case slices.Contains(opts.pushLocation, "notes"):
+			}
+			if slices.Contains(opts.pushLocation, pushRepoNote) {
 				pushAttestations = true
 				notesStorer = true
-			case len(opts.pushRepositories) > 0:
+			}
+			if len(opts.pushRepositories) > 0 {
 				pushAttestations = true
 			}
 


### PR DESCRIPTION
This PR corrects a bug where we were not validating the `--push` flag when specifying the GitHub notes backend.